### PR TITLE
[Wl7-42] 쿠폰 상세 조회

### DIFF
--- a/src/main/java/com/unear/userservice/benefit/dto/response/GeneralDiscountPolicyDetailResponseDto.java
+++ b/src/main/java/com/unear/userservice/benefit/dto/response/GeneralDiscountPolicyDetailResponseDto.java
@@ -29,7 +29,7 @@ public class GeneralDiscountPolicyDetailResponseDto {
         Place place = detail.getPlace();
 
         return GeneralDiscountPolicyDetailResponseDto.builder()
-                .placeId(place.getPlacesId())
+                .placeId(place.getPlaceId())
                 .placeName(place.getPlaceName())
                 .address(place.getAddress())
                 .startTime(place.getStartTime())

--- a/src/main/java/com/unear/userservice/benefit/entity/RouletteResult.java
+++ b/src/main/java/com/unear/userservice/benefit/entity/RouletteResult.java
@@ -13,14 +13,14 @@ import lombok.Setter;
 public class RouletteResult {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long rouletteResultsId;
+    private Long rouletteResultId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "unear_events_id")
+    @JoinColumn(name = "unear_event_id")
     private UnearEvent event;
 
     private String reward;

--- a/src/main/java/com/unear/userservice/benefit/repository/FranchiseDiscountPolicyRepository.java
+++ b/src/main/java/com/unear/userservice/benefit/repository/FranchiseDiscountPolicyRepository.java
@@ -1,0 +1,16 @@
+package com.unear.userservice.benefit.repository;
+
+import com.unear.userservice.benefit.entity.FranchiseDiscountPolicy;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+
+public interface FranchiseDiscountPolicyRepository extends JpaRepository<FranchiseDiscountPolicy, Long> {
+
+    @Query("SELECT f.franchiseDiscountPolicyId FROM FranchiseDiscountPolicy f WHERE f.franchise.franchiseId = :franchiseId")
+    List<Long> findPolicyIdsByFranchiseId(@Param("franchiseId") Long franchiseId);
+
+}

--- a/src/main/java/com/unear/userservice/benefit/repository/GeneralDiscountPolicyRepository.java
+++ b/src/main/java/com/unear/userservice/benefit/repository/GeneralDiscountPolicyRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface GeneralDiscountPolicyRepository extends JpaRepository<GeneralDiscountPolicy, Long>, JpaSpecificationExecutor<GeneralDiscountPolicy> {
@@ -18,6 +19,9 @@ public interface GeneralDiscountPolicyRepository extends JpaRepository<GeneralDi
         WHERE d.generalDiscountPolicyId = :id
     """)
     Optional<GeneralDiscountPolicy> findWithPlaceAndFranchiseById(@Param("id") Long id);
+
+    @Query("SELECT p.generalDiscountPolicyId FROM GeneralDiscountPolicy p WHERE p.place.placeId = :placeId")
+    List<Long> findPolicyIdsByPlaceId(@Param("placeId") Long placeId);
 
 }
 

--- a/src/main/java/com/unear/userservice/common/enums/DiscountPolicy.java
+++ b/src/main/java/com/unear/userservice/common/enums/DiscountPolicy.java
@@ -1,5 +1,6 @@
 package com.unear.userservice.common.enums;
 
+import com.unear.userservice.exception.exception.InvalidCodeException;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -26,7 +27,7 @@ public enum DiscountPolicy {
         return Arrays.stream(values())
                 .filter(p -> p.code.equalsIgnoreCase(code))
                 .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("Invalid DiscountPolicy code: " + code));
+                .orElseThrow(() -> new InvalidCodeException("Invalid DiscountPolicy code: " + code));
     }
 }
 

--- a/src/main/java/com/unear/userservice/common/enums/DiscountPolicy.java
+++ b/src/main/java/com/unear/userservice/common/enums/DiscountPolicy.java
@@ -1,0 +1,32 @@
+package com.unear.userservice.common.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Arrays;
+
+@Getter
+public enum DiscountPolicy {
+
+    COUPON_FIXED("COUPON_FIXED", "(쿠폰) 금액 할인"),
+    COUPON_PERCENT("COUPON_PERCENT", "(쿠폰) 퍼센트 할인"),
+    MEMBERSHIP_UNIT("MEMBERSHIP_UNIT", "(멤버십) 금액당 할인"),
+    MEMBERSHIP_FIXED("MEMBERSHIP_FIXED", "(멤버십) 금액 할인"),
+    COUPON_FCFS("COUPON_FCFS", "선착순 전용 쿠폰");
+
+    private final String code;
+    private final String label;
+
+    DiscountPolicy(String code, String label) {
+        this.code = code;
+        this.label = label;
+    }
+
+    public static DiscountPolicy fromCode(String code) {
+        return Arrays.stream(values())
+                .filter(p -> p.code.equalsIgnoreCase(code))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Invalid DiscountPolicy code: " + code));
+    }
+}
+

--- a/src/main/java/com/unear/userservice/common/enums/MembershipGrade.java
+++ b/src/main/java/com/unear/userservice/common/enums/MembershipGrade.java
@@ -1,5 +1,6 @@
 package com.unear.userservice.common.enums;
 
+import com.unear.userservice.exception.exception.InvalidCodeException;
 import lombok.Getter;
 
 import java.util.Arrays;
@@ -24,6 +25,6 @@ public enum MembershipGrade {
         return Arrays.stream(values())
                 .filter(g -> g.code.equalsIgnoreCase(code))
                 .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("Invalid membership code: " + code));
+                .orElseThrow(() -> new InvalidCodeException("Invalid membership code: " + code));
     }
 }

--- a/src/main/java/com/unear/userservice/common/enums/PlaceType.java
+++ b/src/main/java/com/unear/userservice/common/enums/PlaceType.java
@@ -1,0 +1,31 @@
+package com.unear.userservice.common.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Arrays;
+
+@Getter
+public enum PlaceType {
+
+    LOCAL("LOCAL", "우리동네멤버십"),
+    BASIC("BASIC", "기본혜택"),
+    FRANCHISE("FRANCHISE", "프랜차이즈"),
+    POPUP("POPUP", "팝업스토어");
+
+    private final String code;
+    private final String label;
+
+    PlaceType(String code, String label) {
+        this.code = code;
+        this.label = label;
+    }
+
+    public static PlaceType fromCode(String code) {
+        return Arrays.stream(values())
+                .filter(type -> type.code.equalsIgnoreCase(code))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Invalid place type code: " + code));
+    }
+}
+

--- a/src/main/java/com/unear/userservice/common/enums/PlaceType.java
+++ b/src/main/java/com/unear/userservice/common/enums/PlaceType.java
@@ -1,5 +1,6 @@
 package com.unear.userservice.common.enums;
 
+import com.unear.userservice.exception.exception.InvalidCodeException;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -25,7 +26,7 @@ public enum PlaceType {
         return Arrays.stream(values())
                 .filter(type -> type.code.equalsIgnoreCase(code))
                 .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("Invalid place type code: " + code));
+                .orElseThrow(() -> new InvalidCodeException("Invalid place type code: " + code));
     }
 
     public boolean isBasic() {

--- a/src/main/java/com/unear/userservice/common/enums/PlaceType.java
+++ b/src/main/java/com/unear/userservice/common/enums/PlaceType.java
@@ -27,5 +27,22 @@ public enum PlaceType {
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("Invalid place type code: " + code));
     }
+
+    public boolean isBasic() {
+        return this == BASIC;
+    }
+
+    public boolean isFranchise() {
+        return this == FRANCHISE;
+    }
+
+    public boolean isLocal() {
+        return this == LOCAL;
+    }
+
+    public boolean isPopup() {
+        return this == POPUP;
+    }
+
 }
 

--- a/src/main/java/com/unear/userservice/coupon/controller/CouponController.java
+++ b/src/main/java/com/unear/userservice/coupon/controller/CouponController.java
@@ -1,0 +1,38 @@
+package com.unear.userservice.coupon.controller;
+
+
+import com.unear.userservice.common.response.ApiResponse;
+import com.unear.userservice.common.security.CustomUser;
+import com.unear.userservice.coupon.dto.response.CouponResponseDto;
+import com.unear.userservice.coupon.service.CouponService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/coupons")
+@RequiredArgsConstructor
+public class CouponController {
+
+    private final CouponService couponService;
+
+    // placeId & markerCode로 해당 장소의 쿠폰 템플릿 조회
+    @GetMapping("/{placeId}")
+    public ResponseEntity<ApiResponse<List<CouponResponseDto>>> getCouponsByPlace(
+            @PathVariable("placeId") Long placeId,
+            @RequestParam String markerCode,
+            @AuthenticationPrincipal CustomUser user
+    ) {
+        Long userId = (user != null && user.getUser() != null) ? user.getUser().getUserId() : null;
+        List<CouponResponseDto> result = couponService.getCouponsByPlaceAndMarker(userId, placeId, markerCode);
+        return ResponseEntity.ok(ApiResponse.success("쿠폰 템플릿 조회 성공", result));
+    }
+
+    // {쿠폰템플릿 id}/download
+
+}
+
+

--- a/src/main/java/com/unear/userservice/coupon/controller/CouponController.java
+++ b/src/main/java/com/unear/userservice/coupon/controller/CouponController.java
@@ -31,6 +31,7 @@ public class CouponController {
     }
 
     // {쿠폰템플릿 id}/download
+    // 다운로드하면, unused 인채로 user_coupon
 
 }
 

--- a/src/main/java/com/unear/userservice/coupon/controller/CouponController.java
+++ b/src/main/java/com/unear/userservice/coupon/controller/CouponController.java
@@ -19,7 +19,6 @@ public class CouponController {
 
     private final CouponService couponService;
 
-    // placeId & markerCode로 해당 장소의 쿠폰 템플릿 조회
     @GetMapping("/{placeId}")
     public ResponseEntity<ApiResponse<List<CouponResponseDto>>> getCouponsByPlace(
             @PathVariable("placeId") Long placeId,

--- a/src/main/java/com/unear/userservice/coupon/dto/response/CouponResponseDto.java
+++ b/src/main/java/com/unear/userservice/coupon/dto/response/CouponResponseDto.java
@@ -1,0 +1,37 @@
+package com.unear.userservice.coupon.dto.response;
+
+import com.unear.userservice.coupon.entity.CouponTemplate;
+import lombok.Builder;
+import lombok.Getter;
+
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class CouponResponseDto {
+
+    private Long couponTemplateId;
+    private String couponName;
+    private String discountCode;
+    private String membershipCode;
+    private String discountInfo;
+    private LocalDate couponStart;
+    private LocalDate couponEnd;
+
+    private boolean isDownloaded;
+
+    public static CouponResponseDto from(CouponTemplate entity, String discountInfo, boolean isDownloaded) {
+        return CouponResponseDto.builder()
+                .couponTemplateId(entity.getCouponTemplateId())
+                .couponName(entity.getCouponName())
+                .discountCode(entity.getDiscountCode())
+                .membershipCode(entity.getMembershipCode())
+                .discountInfo(discountInfo)
+                .couponStart(entity.getCouponStart())
+                .couponEnd(entity.getCouponEnd())
+                .isDownloaded(isDownloaded)
+                .build();
+    }
+}
+

--- a/src/main/java/com/unear/userservice/coupon/entity/CouponTemplate.java
+++ b/src/main/java/com/unear/userservice/coupon/entity/CouponTemplate.java
@@ -18,7 +18,7 @@ public class CouponTemplate {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long couponTemplatesId;
 
-    private Long discountPolicyDetailId; // 할인 정책 상세 id , erd 상으로는 연결 X , 추후에 연관관계 고려
+    private Long discountPolicyDetailId;
 
     private String couponName;
     private String couponDesc;
@@ -29,8 +29,10 @@ public class CouponTemplate {
 
     private String discountCode;
     private String membershipCode;
+    private String markerCode;
 
     @OneToMany(mappedBy = "couponTemplate")
     private List<UserCoupon> userCoupons = new ArrayList<>();
 }
+
 

--- a/src/main/java/com/unear/userservice/coupon/entity/CouponTemplate.java
+++ b/src/main/java/com/unear/userservice/coupon/entity/CouponTemplate.java
@@ -20,8 +20,9 @@ public class CouponTemplate {
 
     private Long discountPolicyDetailId;
 
+    private String markerCode;
     private String couponName;
-    private String couponDesc;
+
     private Integer remainingQuantity;
 
     private LocalDate couponStart;
@@ -29,7 +30,6 @@ public class CouponTemplate {
 
     private String discountCode;
     private String membershipCode;
-    private String markerCode;
 
     @OneToMany(mappedBy = "couponTemplate")
     private List<UserCoupon> userCoupons = new ArrayList<>();

--- a/src/main/java/com/unear/userservice/coupon/entity/CouponTemplate.java
+++ b/src/main/java/com/unear/userservice/coupon/entity/CouponTemplate.java
@@ -16,7 +16,7 @@ public class CouponTemplate {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long couponTemplatesId;
+    private Long couponTemplateId;
 
     private Long discountPolicyDetailId;
 

--- a/src/main/java/com/unear/userservice/coupon/entity/UserCoupon.java
+++ b/src/main/java/com/unear/userservice/coupon/entity/UserCoupon.java
@@ -5,13 +5,16 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.time.LocalDate;
+
 @Entity
 @Table(name = "user_coupons")
 @Getter
 @Setter
 public class UserCoupon {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long userCouponsId;
 
     @ManyToOne
@@ -22,7 +25,11 @@ public class UserCoupon {
     @JoinColumn(name = "coupon_templates_id", nullable = false)
     private CouponTemplate couponTemplate;
 
+    private LocalDate createdAt;
+    private LocalDate usedAt;
+
     private String couponStatusCode;
     private String barcodeNumber;
 }
+
 

--- a/src/main/java/com/unear/userservice/coupon/entity/UserCoupon.java
+++ b/src/main/java/com/unear/userservice/coupon/entity/UserCoupon.java
@@ -15,14 +15,14 @@ public class UserCoupon {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long userCouponsId;
+    private Long userCouponId;
 
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     @ManyToOne
-    @JoinColumn(name = "coupon_templates_id", nullable = false)
+    @JoinColumn(name = "coupon_template_id", nullable = false)
     private CouponTemplate couponTemplate;
 
     private LocalDate createdAt;

--- a/src/main/java/com/unear/userservice/coupon/repository/CouponTemplateRepository.java
+++ b/src/main/java/com/unear/userservice/coupon/repository/CouponTemplateRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface CouponTemplateRepository extends JpaRepository<CouponTemplate, Long> {
-    List<CouponTemplate> findByDiscountPolicyDetailIdIn(List<Long> discountPolicyDetailIds);
+    List<CouponTemplate> findByDiscountPolicyDetailIdInAndMarkerCode(List<Long> discountPolicyIds, String markerCode);
 }

--- a/src/main/java/com/unear/userservice/coupon/repository/CouponTemplateRepository.java
+++ b/src/main/java/com/unear/userservice/coupon/repository/CouponTemplateRepository.java
@@ -1,0 +1,10 @@
+package com.unear.userservice.coupon.repository;
+
+import com.unear.userservice.coupon.entity.CouponTemplate;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CouponTemplateRepository extends JpaRepository<CouponTemplate, Long> {
+    List<CouponTemplate> findByDiscountPolicyDetailIdIn(List<Long> discountPolicyDetailIds);
+}

--- a/src/main/java/com/unear/userservice/coupon/repository/UserCouponRepository.java
+++ b/src/main/java/com/unear/userservice/coupon/repository/UserCouponRepository.java
@@ -1,0 +1,19 @@
+package com.unear.userservice.coupon.repository;
+
+import com.unear.userservice.coupon.entity.UserCoupon;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Set;
+
+public interface UserCouponRepository extends JpaRepository<UserCoupon, Long> {
+
+    @Query("""
+        SELECT uc.couponTemplate.couponTemplateId
+        FROM UserCoupon uc
+        WHERE uc.user.userId = :userId
+    """)
+    Set<Long> findCouponTemplateIdsByUserId(@Param("userId") Long userId);
+
+}

--- a/src/main/java/com/unear/userservice/coupon/service/CouponService.java
+++ b/src/main/java/com/unear/userservice/coupon/service/CouponService.java
@@ -1,0 +1,11 @@
+package com.unear.userservice.coupon.service;
+
+import com.unear.userservice.coupon.dto.response.CouponResponseDto;
+
+import java.util.List;
+
+public interface CouponService {
+
+    List<CouponResponseDto> getCouponsByPlaceAndMarker(Long userId ,Long placeId, String markerCode);
+
+}

--- a/src/main/java/com/unear/userservice/coupon/service/impl/CouponServiceImpl.java
+++ b/src/main/java/com/unear/userservice/coupon/service/impl/CouponServiceImpl.java
@@ -12,6 +12,7 @@ import com.unear.userservice.coupon.service.CouponService;
 import com.unear.userservice.place.repository.PlaceRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -28,6 +29,7 @@ public class CouponServiceImpl implements CouponService {
     private final UserCouponRepository userCouponRepository;
 
     @Override
+    @Transactional
     public List<CouponResponseDto> getCouponsByPlaceAndMarker(Long userId, Long placeId, String markerCode) {
         PlaceType placeType = PlaceType.fromCode(markerCode);
 
@@ -55,7 +57,6 @@ public class CouponServiceImpl implements CouponService {
                 .map(template -> {
                     String discountInfo = DiscountPolicy.fromCode(template.getDiscountCode()).getLabel();
                     boolean isDownloaded = downloadedIds.contains(template.getCouponTemplateId());
-
                     return CouponResponseDto.from(template, discountInfo, isDownloaded);
                 })
                 .toList();

--- a/src/main/java/com/unear/userservice/coupon/service/impl/CouponServiceImpl.java
+++ b/src/main/java/com/unear/userservice/coupon/service/impl/CouponServiceImpl.java
@@ -1,0 +1,64 @@
+package com.unear.userservice.coupon.service.impl;
+
+import com.unear.userservice.benefit.repository.FranchiseDiscountPolicyRepository;
+import com.unear.userservice.benefit.repository.GeneralDiscountPolicyRepository;
+import com.unear.userservice.common.enums.DiscountPolicy;
+import com.unear.userservice.common.enums.PlaceType;
+import com.unear.userservice.coupon.dto.response.CouponResponseDto;
+import com.unear.userservice.coupon.entity.CouponTemplate;
+import com.unear.userservice.coupon.repository.CouponTemplateRepository;
+import com.unear.userservice.coupon.repository.UserCouponRepository;
+import com.unear.userservice.coupon.service.CouponService;
+import com.unear.userservice.place.repository.PlaceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class CouponServiceImpl implements CouponService {
+
+    private final GeneralDiscountPolicyRepository generalDiscountPolicyRepository;
+    private final FranchiseDiscountPolicyRepository franchiseDiscountPolicyRepository;
+    private final PlaceRepository placeRepository;
+    private final CouponTemplateRepository couponTemplateRepository;
+    private final UserCouponRepository userCouponRepository;
+
+    @Override
+    public List<CouponResponseDto> getCouponsByPlaceAndMarker(Long userId, Long placeId, String markerCode) {
+        PlaceType placeType = PlaceType.fromCode(markerCode);
+
+        List<Long> discountPolicyIds = List.of();
+        if (placeType.isBasic()) {
+            discountPolicyIds = generalDiscountPolicyRepository.findPolicyIdsByPlaceId(placeId);
+        } else if (placeType.isFranchise()) {
+            Optional<Long> franchiseIdOpt = placeRepository.findFranchiseIdByPlaceId(placeId);
+            if (franchiseIdOpt.isEmpty()) return List.of();
+            Long franchiseId = franchiseIdOpt.get();
+            discountPolicyIds = franchiseDiscountPolicyRepository.findPolicyIdsByFranchiseId(franchiseId);
+        }
+
+        if (discountPolicyIds.isEmpty()) return List.of();
+
+        List<CouponTemplate> templates = couponTemplateRepository
+                .findByDiscountPolicyDetailIdInAndMarkerCode(discountPolicyIds, placeType.getCode());
+
+
+        Set<Long> downloadedIds = (userId != null)
+                ? userCouponRepository.findCouponTemplateIdsByUserId(userId)
+                : Set.of();
+
+        return templates.stream()
+                .map(template -> {
+                    String discountInfo = DiscountPolicy.fromCode(template.getDiscountCode()).getLabel();
+                    boolean isDownloaded = downloadedIds.contains(template.getCouponTemplateId());
+
+                    return CouponResponseDto.from(template, discountInfo, isDownloaded);
+                })
+                .toList();
+    }
+
+}

--- a/src/main/java/com/unear/userservice/event/entity/UnearEvent.java
+++ b/src/main/java/com/unear/userservice/event/entity/UnearEvent.java
@@ -17,9 +17,9 @@ import java.util.List;
 @Setter
 public class UnearEvent {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long unearEventsId;
+    private Long unearEventId;
 
-    private Long couponTemplatesId;
+    private Long couponTemplateId;
     private String eventName;
     private String eventDescription;
 

--- a/src/main/java/com/unear/userservice/exception/ErrorCode.java
+++ b/src/main/java/com/unear/userservice/exception/ErrorCode.java
@@ -19,7 +19,8 @@ public enum ErrorCode {
     DUPLICATED_EMAIL(HttpStatus.BAD_REQUEST, "DUPLICATED_EMAIL", "이미 가입된 이메일입니다."),
     EMAIL_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "EMAIL_NOT_VERIFIED", "이메일 인증이 필요합니다."),
     BENEFIT_NOT_FOUND(HttpStatus.NOT_FOUND, "BENEFIT_NOT_FOUND" , "혜택 정보를 찾을 수 없습니다."),
-    PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "PLACE_NOT_FOUND", "장소 정보를 찾을 수 없습니다.")
+    PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "PLACE_NOT_FOUND", "장소 정보를 찾을 수 없습니다."),
+    INVALID_CODE(HttpStatus.NOT_FOUND, "INVALID_CODE", "유효하지 않은 공통코드입니다.")
     ;
 
 

--- a/src/main/java/com/unear/userservice/exception/exception/InvalidCodeException.java
+++ b/src/main/java/com/unear/userservice/exception/exception/InvalidCodeException.java
@@ -1,0 +1,14 @@
+package com.unear.userservice.exception.exception;
+
+import com.unear.userservice.exception.BusinessException;
+import com.unear.userservice.exception.ErrorCode;
+
+public class InvalidCodeException extends BusinessException {
+    public InvalidCodeException() {
+        super(ErrorCode.INVALID_CODE);
+    }
+
+    public InvalidCodeException(String message) {
+        super(ErrorCode.INVALID_CODE, message);
+    }
+}

--- a/src/main/java/com/unear/userservice/place/dto/request/PlaceRequestDto.java
+++ b/src/main/java/com/unear/userservice/place/dto/request/PlaceRequestDto.java
@@ -14,8 +14,9 @@ public class PlaceRequestDto {
     private String benefitCategory;
     private Boolean isFavorite;
 
-    private Double minLatitude;  // 좌하단 위도
-    private Double minLongitude; // 좌하단 경도
-    private Double maxLatitude;  // 우상단 위도
-    private Double maxLongitude; // 우상단 경도
+    private Double southWestLatitude;
+    private Double southWestLongitude;
+    private Double northEastLatitude;
+    private Double northEastLongitude;
+
 }

--- a/src/main/java/com/unear/userservice/place/dto/response/PlaceRenderResponseDto.java
+++ b/src/main/java/com/unear/userservice/place/dto/response/PlaceRenderResponseDto.java
@@ -22,7 +22,7 @@ public class PlaceRenderResponseDto {
 
     public static PlaceRenderResponseDto from(Place place, boolean isFavorite) {
         return PlaceRenderResponseDto.builder()
-                .placeId(place.getPlacesId())
+                .placeId(place.getPlaceId())
                 .latitude(place.getLatitude())
                 .longitude(place.getLongitude())
                 .categoryCode(place.getCategoryCode())

--- a/src/main/java/com/unear/userservice/place/dto/response/PlaceResponseDto.java
+++ b/src/main/java/com/unear/userservice/place/dto/response/PlaceResponseDto.java
@@ -26,7 +26,7 @@ public class PlaceResponseDto {
 
     public static PlaceResponseDto from(Place place, boolean isFavorite) {
         return PlaceResponseDto.builder()
-                .placeId(place.getPlacesId())
+                .placeId(place.getPlaceId())
                 .placeName(place.getPlaceName())
                 .placeDesc(place.getPlaceDesc())
                 .address(place.getAddress())

--- a/src/main/java/com/unear/userservice/place/entity/EventPlace.java
+++ b/src/main/java/com/unear/userservice/place/entity/EventPlace.java
@@ -15,14 +15,14 @@ import java.util.List;
 @Setter
 public class EventPlace {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long eventPlacesId;
+    private Long eventPlaceId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "unear_events_id")
+    @JoinColumn(name = "unear_event_id")
     private UnearEvent event;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "places_id")
+    @JoinColumn(name = "place_id")
     private Place place;
 
     private String eventCode;

--- a/src/main/java/com/unear/userservice/place/entity/FavoritePlace.java
+++ b/src/main/java/com/unear/userservice/place/entity/FavoritePlace.java
@@ -15,14 +15,14 @@ public class FavoritePlace {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long favoritePlacesId;
+    private Long favoritePlaceId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "places_id", nullable = false)
+    @JoinColumn(name = "place_id", nullable = false)
     private Place place;
 
     private LocalDateTime createdAt;

--- a/src/main/java/com/unear/userservice/place/entity/Place.java
+++ b/src/main/java/com/unear/userservice/place/entity/Place.java
@@ -16,7 +16,7 @@ public class Place {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long placesId;
+    private Long placeId;
 
     private String placeName;
     private String placeDesc;

--- a/src/main/java/com/unear/userservice/place/repository/FavoritePlaceRepository.java
+++ b/src/main/java/com/unear/userservice/place/repository/FavoritePlaceRepository.java
@@ -10,13 +10,13 @@ import java.util.Set;
 
 public interface FavoritePlaceRepository extends JpaRepository<FavoritePlace, Long> {
 
-    @Query("SELECT f.place.placesId FROM FavoritePlace f " +
+    @Query("SELECT f.place.placeId FROM FavoritePlace f " +
             "WHERE f.user.userId = :userId AND f.isFavorited = true")
     Set<Long> findPlaceIdsByUserId(@Param("userId") Long userId);
 
-    boolean existsByUser_UserIdAndPlace_PlacesIdAndIsFavoritedTrue(Long userId, Long placeId);
+    boolean existsByUser_UserIdAndPlace_PlaceIdAndIsFavoritedTrue(Long userId, Long placeId);
 
-    Optional<FavoritePlace> findByUser_UserIdAndPlace_PlacesId(Long userId, Long placeId);
+    Optional<FavoritePlace> findByUser_UserIdAndPlace_PlaceId(Long userId, Long placeId);
 
 
 }

--- a/src/main/java/com/unear/userservice/place/repository/PlaceRepository.java
+++ b/src/main/java/com/unear/userservice/place/repository/PlaceRepository.java
@@ -25,24 +25,24 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
       OR (:isFavorite = TRUE AND f.isFavorited = TRUE)
       OR (:isFavorite = FALSE AND (f IS NULL OR f.isFavorited = FALSE))
     )
-    AND (:minLatitude IS NULL OR p.latitude >= :minLatitude)
-    AND (:maxLatitude IS NULL OR p.latitude <= :maxLatitude)
-    AND (:minLongitude IS NULL OR p.longitude >= :minLongitude)
-    AND (:maxLongitude IS NULL OR p.longitude <= :maxLongitude)
+    AND (:southWestLatitude IS NULL OR p.latitude >= :southWestLatitude)
+    AND (:northEastLatitude IS NULL OR p.latitude <= :northEastLatitude)
+    AND (:southWestLongitude IS NULL OR p.longitude >= :southWestLongitude)
+    AND (:northEastLongitude IS NULL OR p.longitude <= :northEastLongitude)
 """)
     List<Place> findFilteredPlaces(
             @Param("userId") Long userId,
             @Param("categoryCode") String categoryCode,
             @Param("benefitCategory") String benefitCategory,
             @Param("isFavorite") Boolean isFavorite,
-            @Param("minLatitude") Double minLatitude,
-            @Param("maxLatitude") Double maxLatitude,
-            @Param("minLongitude") Double minLongitude,
-            @Param("maxLongitude") Double maxLongitude
+            @Param("southWestLatitude") Double southWestLatitude,
+            @Param("northEastLatitude") Double northEastLatitude,
+            @Param("southWestLongitude") Double southWestLongitude,
+            @Param("northEastLongitude") Double northEastLongitude
     );
 
-
-
+    @Query("SELECT p.franchise.franchiseId FROM Place p WHERE p.placesId = :placeId")
+    Optional<Long> findFranchiseIdByPlaceId(@Param("placeId") Long placeId);
 
 
 }

--- a/src/main/java/com/unear/userservice/place/repository/PlaceRepository.java
+++ b/src/main/java/com/unear/userservice/place/repository/PlaceRepository.java
@@ -41,7 +41,7 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
             @Param("northEastLongitude") Double northEastLongitude
     );
 
-    @Query("SELECT p.franchise.franchiseId FROM Place p WHERE p.placesId = :placeId")
+    @Query("SELECT p.franchise.franchiseId FROM Place p WHERE p.placeId = :placeId")
     Optional<Long> findFranchiseIdByPlaceId(@Param("placeId") Long placeId);
 
 

--- a/src/main/java/com/unear/userservice/place/service/impl/PlaceServiceImpl.java
+++ b/src/main/java/com/unear/userservice/place/service/impl/PlaceServiceImpl.java
@@ -36,10 +36,10 @@ public class PlaceServiceImpl implements PlaceService {
                 requestDto.getCategoryCode(),
                 requestDto.getBenefitCategory(),
                 requestDto.getIsFavorite(),
-                requestDto.getMinLatitude(),
-                requestDto.getMaxLatitude(),
-                requestDto.getMinLongitude(),
-                requestDto.getMaxLongitude()
+                requestDto.getSouthWestLatitude(),
+                requestDto.getNorthEastLatitude(),
+                requestDto.getSouthWestLongitude(),
+                requestDto.getNorthEastLongitude()
         );
 
         Set<Long> favorites = (userId != null)

--- a/src/main/java/com/unear/userservice/place/service/impl/PlaceServiceImpl.java
+++ b/src/main/java/com/unear/userservice/place/service/impl/PlaceServiceImpl.java
@@ -47,7 +47,7 @@ public class PlaceServiceImpl implements PlaceService {
                 : Collections.emptySet();
 
         return places.stream()
-                .map(place -> PlaceRenderResponseDto.from(place, favorites.contains(place.getPlacesId())))
+                .map(place -> PlaceRenderResponseDto.from(place, favorites.contains(place.getPlaceId())))
                 .toList();
     }
 
@@ -59,7 +59,7 @@ public class PlaceServiceImpl implements PlaceService {
 
         boolean isFavorite = false;
         if (userId != null) {
-            isFavorite = favoritePlaceRepository.existsByUser_UserIdAndPlace_PlacesIdAndIsFavoritedTrue(userId, placeId);
+            isFavorite = favoritePlaceRepository.existsByUser_UserIdAndPlace_PlaceIdAndIsFavoritedTrue(userId, placeId);
         }
         return PlaceResponseDto.from(place, isFavorite);
     }
@@ -68,7 +68,7 @@ public class PlaceServiceImpl implements PlaceService {
     @Override
     @Transactional
     public boolean toggleFavorite(Long userId, Long placeId) {
-        Optional<FavoritePlace> optional = favoritePlaceRepository.findByUser_UserIdAndPlace_PlacesId(userId, placeId);
+        Optional<FavoritePlace> optional = favoritePlaceRepository.findByUser_UserIdAndPlace_PlaceId(userId, placeId);
 
         if (optional.isPresent()) {
             FavoritePlace favorite = optional.get();

--- a/src/main/java/com/unear/userservice/stamp/entity/Stamp.java
+++ b/src/main/java/com/unear/userservice/stamp/entity/Stamp.java
@@ -14,14 +14,14 @@ import java.time.LocalDateTime;
 @Setter
 public class Stamp {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long stampsId;
+    private Long stampId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "event_places_id")
+    @JoinColumn(name = "event_place_id")
     private EventPlace eventPlace;
 
     private LocalDateTime stampedAt;


### PR DESCRIPTION
## PR 목적

- 어떤 기능을 **왜** 추가/수정했는지 목적 위주로 간단히 서술
- 코드래빗 요약 + 이 설명만으로도 맥락이 명확해야 함


## 변경 사항

- [WL7-50] 쿠폰 상세 조회 로직 추가



## 주요 구현 내용

- 엔티티 id -> 단수형으로 일괄 수정
- 좌하단, 우상단 위도/경도 필드명 수정
- DiscountPolicy Enum 타입 추가
- PlaceType Enum 코드 일치 여부 메서드 추가
- placeId + makerCode로 해당 장소의 쿠폰 템플릿 조회
- markerCode가 BASIC, FRANCHISE에 따라서 서로 다른 할인정책 테이블 참조
<img width="600" height="1026" alt="image" src="https://github.com/user-attachments/assets/abc25d1e-c218-4999-b095-1085339d6fbd" />


## 테스트 및 동작 화면 (필요 시 첨부)

- placeId & markerCode == BASIC -> 기본 혜택 장소의 쿠폰 템플릿 조회
<img width="348" height="314" alt="스크린샷 2025-07-17 오후 1 12 06" src="https://github.com/user-attachments/assets/3634c9bb-2f66-4239-93a4-f11a1a4429cc" />

- placeId & markerCode == FRANCHISE -> 프랜차이즈 장소의 쿠폰 템플릿 조회
<img width="347" height="673" alt="스크린샷 2025-07-17 오후 1 13 13" src="https://github.com/user-attachments/assets/32479e76-71b4-49db-8156-1f46327e0f0c" />


## 리뷰 시 중점적으로 봐야 할 부분

- 할인 정책 상세 id & 장소 유형 코드로 쿠폰 템플릿 id 리스트 조회하는 로직 올바른지
- PlaceType Enum 타입 코드 일치 여부 로직 올바른지

## 병합 전 체크리스트

- [v] 로컬 테스트 완료
- [v] Postman 테스트 포함
- [ ] 코드래빗 리뷰 검토


[WL7-50]: https://lguplus20250120.atlassian.net/browse/WL7-50?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ