### PR TITLE
[WL7-52] 쿠폰 다운로드

### DIFF
--- a/src/main/java/com/unear/userservice/common/enums/CouponStatus.java
+++ b/src/main/java/com/unear/userservice/common/enums/CouponStatus.java
@@ -26,12 +26,5 @@ public enum CouponStatus {
                 .orElseThrow(() -> new InvalidCodeException("Invalid coupon status code: " + code));
     }
 
-    public String getCode() {
-        return code;
-    }
-
-    public String getLabel() {
-        return label;
-    }
 }
 

--- a/src/main/java/com/unear/userservice/common/enums/CouponStatus.java
+++ b/src/main/java/com/unear/userservice/common/enums/CouponStatus.java
@@ -1,0 +1,37 @@
+package com.unear.userservice.common.enums;
+
+import com.unear.userservice.exception.exception.InvalidCodeException;
+import lombok.Getter;
+
+import java.util.Arrays;
+
+@Getter
+public enum CouponStatus {
+    UNUSED("UNUSED", "미사용"),
+    USED("USED", "사용됨"),
+    EXPIRED("EXPIRED", "기간만료");
+
+    private final String code;
+    private final String label;
+
+    CouponStatus(String code, String label) {
+        this.code = code;
+        this.label = label;
+    }
+
+    public static CouponStatus fromCode(String code) {
+        return Arrays.stream(values())
+                .filter(c -> c.code.equalsIgnoreCase(code))
+                .findFirst()
+                .orElseThrow(() -> new InvalidCodeException("Invalid coupon status code: " + code));
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+}
+

--- a/src/main/java/com/unear/userservice/coupon/controller/CouponController.java
+++ b/src/main/java/com/unear/userservice/coupon/controller/CouponController.java
@@ -41,6 +41,16 @@ public class CouponController {
         return ResponseEntity.ok(ApiResponse.success("쿠폰 다운로드 성공", response));
     }
 
+    @PostMapping("/{couponTemplateId}/fcfs")
+    public ResponseEntity<ApiResponse<UserCouponResponseDto>> downloadFCFSCoupon(
+            @PathVariable Long couponTemplateId,
+            @AuthenticationPrincipal CustomUser user
+    ) {
+        Long userId = (user != null && user.getUser() != null) ? user.getUser().getUserId() : null;
+        UserCouponResponseDto response = couponService.downloadFCFSCoupon(userId, couponTemplateId);
+        return ResponseEntity.ok(ApiResponse.success("쿠폰 다운로드 성공", response));
+    }
+
 }
 
 

--- a/src/main/java/com/unear/userservice/coupon/controller/CouponController.java
+++ b/src/main/java/com/unear/userservice/coupon/controller/CouponController.java
@@ -4,6 +4,7 @@ package com.unear.userservice.coupon.controller;
 import com.unear.userservice.common.response.ApiResponse;
 import com.unear.userservice.common.security.CustomUser;
 import com.unear.userservice.coupon.dto.response.CouponResponseDto;
+import com.unear.userservice.coupon.dto.response.UserCouponResponseDto;
 import com.unear.userservice.coupon.service.CouponService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -30,8 +31,15 @@ public class CouponController {
         return ResponseEntity.ok(ApiResponse.success("쿠폰 템플릿 조회 성공", result));
     }
 
-    // {쿠폰템플릿 id}/download
-    // 다운로드하면, unused 인채로 user_coupon
+    @PostMapping("/{couponTemplateId}/download")
+    public ResponseEntity<ApiResponse<UserCouponResponseDto>> downloadCoupon(
+            @PathVariable Long couponTemplateId,
+            @AuthenticationPrincipal CustomUser user
+    ) {
+        Long userId = (user != null && user.getUser() != null) ? user.getUser().getUserId() : null;
+        UserCouponResponseDto response = couponService.downloadCoupon(userId, couponTemplateId);
+        return ResponseEntity.ok(ApiResponse.success("쿠폰 다운로드 성공", response));
+    }
 
 }
 

--- a/src/main/java/com/unear/userservice/coupon/dto/response/UserCouponResponseDto.java
+++ b/src/main/java/com/unear/userservice/coupon/dto/response/UserCouponResponseDto.java
@@ -1,0 +1,28 @@
+package com.unear.userservice.coupon.dto.response;
+
+import com.unear.userservice.coupon.entity.UserCoupon;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class UserCouponResponseDto {
+    private Long userCouponId;
+    private String couponName;
+    private String barcodeNumber;
+    private String couponStatusCode;
+    private LocalDate createdAt;
+
+    public static UserCouponResponseDto from(UserCoupon userCoupon) {
+        return UserCouponResponseDto.builder()
+                .userCouponId(userCoupon.getUserCouponId())
+                .couponName(userCoupon.getCouponTemplate().getCouponName())
+                .barcodeNumber(userCoupon.getBarcodeNumber())
+                .couponStatusCode(userCoupon.getCouponStatusCode())
+                .createdAt(userCoupon.getCreatedAt())
+                .build();
+    }
+}
+

--- a/src/main/java/com/unear/userservice/coupon/dto/response/UserCouponResponseDto.java
+++ b/src/main/java/com/unear/userservice/coupon/dto/response/UserCouponResponseDto.java
@@ -18,7 +18,9 @@ public class UserCouponResponseDto {
     public static UserCouponResponseDto from(UserCoupon userCoupon) {
         return UserCouponResponseDto.builder()
                 .userCouponId(userCoupon.getUserCouponId())
-                .couponName(userCoupon.getCouponTemplate().getCouponName())
+                .couponName(userCoupon.getCouponTemplate() != null
+                        ? userCoupon.getCouponTemplate().getCouponName()
+                        : null)
                 .barcodeNumber(userCoupon.getBarcodeNumber())
                 .couponStatusCode(userCoupon.getCouponStatusCode())
                 .createdAt(userCoupon.getCreatedAt())

--- a/src/main/java/com/unear/userservice/coupon/entity/CouponTemplate.java
+++ b/src/main/java/com/unear/userservice/coupon/entity/CouponTemplate.java
@@ -1,5 +1,6 @@
 package com.unear.userservice.coupon.entity;
 
+import com.unear.userservice.exception.exception.CouponSoldOutException;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
@@ -33,6 +34,13 @@ public class CouponTemplate {
 
     @OneToMany(mappedBy = "couponTemplate")
     private List<UserCoupon> userCoupons = new ArrayList<>();
+
+    public void decreaseQuantity() {
+        if (this.remainingQuantity <= 0) {
+            throw new CouponSoldOutException("쿠폰 재고가 없습니다.");
+        }
+        this.remainingQuantity -= 1;
+    }
 }
 
 

--- a/src/main/java/com/unear/userservice/coupon/entity/UserCoupon.java
+++ b/src/main/java/com/unear/userservice/coupon/entity/UserCoupon.java
@@ -2,8 +2,7 @@ package com.unear.userservice.coupon.entity;
 
 import com.unear.userservice.user.entity.User;
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDate;
 
@@ -11,6 +10,9 @@ import java.time.LocalDate;
 @Table(name = "user_coupons")
 @Getter
 @Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class UserCoupon {
 
     @Id

--- a/src/main/java/com/unear/userservice/coupon/repository/UserCouponRepository.java
+++ b/src/main/java/com/unear/userservice/coupon/repository/UserCouponRepository.java
@@ -1,6 +1,8 @@
 package com.unear.userservice.coupon.repository;
 
+import com.unear.userservice.coupon.entity.CouponTemplate;
 import com.unear.userservice.coupon.entity.UserCoupon;
+import com.unear.userservice.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -15,5 +17,7 @@ public interface UserCouponRepository extends JpaRepository<UserCoupon, Long> {
         WHERE uc.user.userId = :userId
     """)
     Set<Long> findCouponTemplateIdsByUserId(@Param("userId") Long userId);
+
+    boolean existsByBarcodeNumber(String barcodeNumber);
 
 }

--- a/src/main/java/com/unear/userservice/coupon/repository/UserCouponRepository.java
+++ b/src/main/java/com/unear/userservice/coupon/repository/UserCouponRepository.java
@@ -1,8 +1,6 @@
 package com.unear.userservice.coupon.repository;
 
-import com.unear.userservice.coupon.entity.CouponTemplate;
 import com.unear.userservice.coupon.entity.UserCoupon;
-import com.unear.userservice.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;

--- a/src/main/java/com/unear/userservice/coupon/service/CouponService.java
+++ b/src/main/java/com/unear/userservice/coupon/service/CouponService.java
@@ -11,4 +11,6 @@ public interface CouponService {
 
     UserCouponResponseDto downloadCoupon(Long userId, Long couponTemplateId);
 
+    UserCouponResponseDto downloadFCFSCoupon(Long userId, Long couponTemplateId);
+
 }

--- a/src/main/java/com/unear/userservice/coupon/service/CouponService.java
+++ b/src/main/java/com/unear/userservice/coupon/service/CouponService.java
@@ -1,11 +1,14 @@
 package com.unear.userservice.coupon.service;
 
 import com.unear.userservice.coupon.dto.response.CouponResponseDto;
+import com.unear.userservice.coupon.dto.response.UserCouponResponseDto;
 
 import java.util.List;
 
 public interface CouponService {
 
     List<CouponResponseDto> getCouponsByPlaceAndMarker(Long userId ,Long placeId, String markerCode);
+
+    UserCouponResponseDto downloadCoupon(Long userId, Long couponTemplateId);
 
 }

--- a/src/main/java/com/unear/userservice/coupon/service/impl/CouponServiceImpl.java
+++ b/src/main/java/com/unear/userservice/coupon/service/impl/CouponServiceImpl.java
@@ -2,21 +2,33 @@ package com.unear.userservice.coupon.service.impl;
 
 import com.unear.userservice.benefit.repository.FranchiseDiscountPolicyRepository;
 import com.unear.userservice.benefit.repository.GeneralDiscountPolicyRepository;
+import com.unear.userservice.common.enums.CouponStatus;
 import com.unear.userservice.common.enums.DiscountPolicy;
 import com.unear.userservice.common.enums.PlaceType;
 import com.unear.userservice.coupon.dto.response.CouponResponseDto;
+import com.unear.userservice.coupon.dto.response.UserCouponResponseDto;
 import com.unear.userservice.coupon.entity.CouponTemplate;
+import com.unear.userservice.coupon.entity.UserCoupon;
 import com.unear.userservice.coupon.repository.CouponTemplateRepository;
 import com.unear.userservice.coupon.repository.UserCouponRepository;
 import com.unear.userservice.coupon.service.CouponService;
+import com.unear.userservice.exception.exception.BarcodeDuplicatedException;
+import com.unear.userservice.exception.exception.CouponAlreadyDownloadedException;
+import com.unear.userservice.exception.exception.CouponTemplateNotFoundException;
+import com.unear.userservice.exception.exception.UserNotFoundException;
 import com.unear.userservice.place.repository.PlaceRepository;
+import com.unear.userservice.user.entity.User;
+import com.unear.userservice.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -27,6 +39,7 @@ public class CouponServiceImpl implements CouponService {
     private final PlaceRepository placeRepository;
     private final CouponTemplateRepository couponTemplateRepository;
     private final UserCouponRepository userCouponRepository;
+    private final UserRepository userRepository;
 
     @Override
     @Transactional
@@ -61,5 +74,47 @@ public class CouponServiceImpl implements CouponService {
                 })
                 .toList();
     }
+
+
+    @Override
+    @Transactional
+    public UserCouponResponseDto downloadCoupon(Long userId, Long couponTemplateId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
+
+        CouponTemplate template = couponTemplateRepository.findById(couponTemplateId)
+                .orElseThrow(() -> new CouponTemplateNotFoundException("쿠폰 템플릿을 찾을 수 없습니다."));
+
+        UserCoupon userCoupon = UserCoupon.builder()
+                .user(user)
+                .couponTemplate(template)
+                .createdAt(LocalDate.now())
+                .couponStatusCode(CouponStatus.UNUSED.getCode())
+                .barcodeNumber(generateUniqueBarcode())
+                .build();
+
+        try {
+            userCouponRepository.save(userCoupon);
+        } catch (DataIntegrityViolationException e) {
+            throw new CouponAlreadyDownloadedException("이미 다운로드한 쿠폰입니다.");
+        }
+
+        return UserCouponResponseDto.from(userCoupon);
+    }
+
+    private String generateUniqueBarcode() {
+        for (int i = 0; i < 3; i++) {
+            String barcode = generateBarcode();
+            if (!userCouponRepository.existsByBarcodeNumber(barcode)) {
+                return barcode;
+            }
+        }
+        throw new BarcodeDuplicatedException("중복된 바코드로 인해 바코드 생성 실패");
+    }
+
+    private String generateBarcode() {
+        return UUID.randomUUID().toString().replace("-", "").substring(0, 16);
+    }
+
 
 }

--- a/src/main/java/com/unear/userservice/coupon/service/impl/CouponServiceImpl.java
+++ b/src/main/java/com/unear/userservice/coupon/service/impl/CouponServiceImpl.java
@@ -82,6 +82,11 @@ public class CouponServiceImpl implements CouponService {
         CouponTemplate template = couponTemplateRepository.findById(couponTemplateId)
                 .orElseThrow(() -> new CouponTemplateNotFoundException("쿠폰 템플릿을 찾을 수 없습니다."));
 
+        LocalDate today = LocalDate.now();
+        if (template.getCouponStart().isAfter(today) || template.getCouponEnd().isBefore(today)) {
+            throw new CouponExpiredException("유효 기간이 지난 쿠폰입니다.");
+        }
+
         UserCoupon userCoupon = UserCoupon.builder()
                 .user(user)
                 .couponTemplate(template)
@@ -107,6 +112,11 @@ public class CouponServiceImpl implements CouponService {
 
         CouponTemplate template = couponTemplateRepository.findById(couponTemplateId)
                 .orElseThrow(() -> new CouponTemplateNotFoundException("쿠폰 템플릿을 찾을 수 없습니다."));
+
+        LocalDate today = LocalDate.now();
+        if (template.getCouponStart().isAfter(today) || template.getCouponEnd().isBefore(today)) {
+            throw new CouponExpiredException("유효 기간이 지난 쿠폰입니다.");
+        }
 
         template.decreaseQuantity();
 

--- a/src/main/java/com/unear/userservice/exception/ErrorCode.java
+++ b/src/main/java/com/unear/userservice/exception/ErrorCode.java
@@ -24,7 +24,8 @@ public enum ErrorCode {
     COUPON_TEMPLATE_NOT_FOUND(HttpStatus.NOT_FOUND , "COUPON_TEMPLATE_NOT_FOUND" , "쿠폰 템플릿을 찾을 수 없습니다." ),
     COUPON_ALREADY_DOWNLOADED(HttpStatus.BAD_REQUEST, "COUPON_ALREADY_DOWNLOADED", "이미 다운로드한 쿠폰입니다."),
     DUPLICATED_BARCODE(HttpStatus.BAD_REQUEST, "DUPLICATED_BARCODE" , "중복된 바코드 번호입니다."),
-    COUPON_SOLD_OUT(HttpStatus.BAD_REQUEST, "COUPON_SOLD_OUT" , "쿠폰 재고가 없습니다.")
+    COUPON_SOLD_OUT(HttpStatus.BAD_REQUEST, "COUPON_SOLD_OUT" , "쿠폰 재고가 없습니다."),
+    COUPON_EXPIRED(HttpStatus.BAD_REQUEST, "COUPON_EXPIRED", "유효 기간이 지난 쿠폰입니다.")
     ;
 
 

--- a/src/main/java/com/unear/userservice/exception/ErrorCode.java
+++ b/src/main/java/com/unear/userservice/exception/ErrorCode.java
@@ -23,7 +23,8 @@ public enum ErrorCode {
     INVALID_CODE(HttpStatus.NOT_FOUND, "INVALID_CODE", "유효하지 않은 공통코드입니다."),
     COUPON_TEMPLATE_NOT_FOUND(HttpStatus.NOT_FOUND , "COUPON_TEMPLATE_NOT_FOUND" , "쿠폰 템플릿을 찾을 수 없습니다." ),
     COUPON_ALREADY_DOWNLOADED(HttpStatus.BAD_REQUEST, "COUPON_ALREADY_DOWNLOADED", "이미 다운로드한 쿠폰입니다."),
-    DUPLICATED_BARCODE(HttpStatus.BAD_REQUEST, "DUPLICATED_BARCODE" , "중복된 바코드 번호입니다.")
+    DUPLICATED_BARCODE(HttpStatus.BAD_REQUEST, "DUPLICATED_BARCODE" , "중복된 바코드 번호입니다."),
+    COUPON_SOLD_OUT(HttpStatus.BAD_REQUEST, "COUPON_SOLD_OUT" , "쿠폰 재고가 없습니다.")
     ;
 
 

--- a/src/main/java/com/unear/userservice/exception/ErrorCode.java
+++ b/src/main/java/com/unear/userservice/exception/ErrorCode.java
@@ -20,7 +20,9 @@ public enum ErrorCode {
     EMAIL_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "EMAIL_NOT_VERIFIED", "이메일 인증이 필요합니다."),
     BENEFIT_NOT_FOUND(HttpStatus.NOT_FOUND, "BENEFIT_NOT_FOUND" , "혜택 정보를 찾을 수 없습니다."),
     PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "PLACE_NOT_FOUND", "장소 정보를 찾을 수 없습니다."),
-    INVALID_CODE(HttpStatus.NOT_FOUND, "INVALID_CODE", "유효하지 않은 공통코드입니다.")
+    INVALID_CODE(HttpStatus.NOT_FOUND, "INVALID_CODE", "유효하지 않은 공통코드입니다."),
+    COUPON_TEMPLATE_NOT_FOUND(HttpStatus.NOT_FOUND , "COUPON_TEMPLATE_NOT_FOUND" , "쿠폰 템플릿을 찾을 수 없습니다." ),
+    COUPON_ALREADY_DOWNLOADED(HttpStatus.BAD_REQUEST, "COUPON_ALREADY_DOWNLOADED", "이미 다운로드한 쿠폰입니다.")
     ;
 
 

--- a/src/main/java/com/unear/userservice/exception/ErrorCode.java
+++ b/src/main/java/com/unear/userservice/exception/ErrorCode.java
@@ -22,7 +22,8 @@ public enum ErrorCode {
     PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "PLACE_NOT_FOUND", "장소 정보를 찾을 수 없습니다."),
     INVALID_CODE(HttpStatus.NOT_FOUND, "INVALID_CODE", "유효하지 않은 공통코드입니다."),
     COUPON_TEMPLATE_NOT_FOUND(HttpStatus.NOT_FOUND , "COUPON_TEMPLATE_NOT_FOUND" , "쿠폰 템플릿을 찾을 수 없습니다." ),
-    COUPON_ALREADY_DOWNLOADED(HttpStatus.BAD_REQUEST, "COUPON_ALREADY_DOWNLOADED", "이미 다운로드한 쿠폰입니다.")
+    COUPON_ALREADY_DOWNLOADED(HttpStatus.BAD_REQUEST, "COUPON_ALREADY_DOWNLOADED", "이미 다운로드한 쿠폰입니다."),
+    DUPLICATED_BARCODE(HttpStatus.BAD_REQUEST, "DUPLICATED_BARCODE" , "중복된 바코드 번호입니다.")
     ;
 
 

--- a/src/main/java/com/unear/userservice/exception/exception/BarcodeDuplicatedException.java
+++ b/src/main/java/com/unear/userservice/exception/exception/BarcodeDuplicatedException.java
@@ -1,0 +1,15 @@
+package com.unear.userservice.exception.exception;
+
+import com.unear.userservice.exception.BusinessException;
+import com.unear.userservice.exception.ErrorCode;
+
+
+public class BarcodeDuplicatedException extends BusinessException {
+    public BarcodeDuplicatedException() {
+        super(ErrorCode.DUPLICATED_BARCODE);
+    }
+
+    public BarcodeDuplicatedException(String message) {
+        super(ErrorCode.DUPLICATED_BARCODE, message);
+    }
+}

--- a/src/main/java/com/unear/userservice/exception/exception/CouponAlreadyDownloadedException.java
+++ b/src/main/java/com/unear/userservice/exception/exception/CouponAlreadyDownloadedException.java
@@ -1,0 +1,15 @@
+package com.unear.userservice.exception.exception;
+
+import com.unear.userservice.exception.BusinessException;
+import com.unear.userservice.exception.ErrorCode;
+
+
+public class CouponAlreadyDownloadedException extends BusinessException {
+    public CouponAlreadyDownloadedException() {
+        super(ErrorCode.COUPON_ALREADY_DOWNLOADED);
+    }
+
+    public CouponAlreadyDownloadedException(String message) {
+        super(ErrorCode.COUPON_ALREADY_DOWNLOADED, message);
+    }
+}

--- a/src/main/java/com/unear/userservice/exception/exception/CouponExpiredException.java
+++ b/src/main/java/com/unear/userservice/exception/exception/CouponExpiredException.java
@@ -1,0 +1,13 @@
+package com.unear.userservice.exception.exception;
+
+import com.unear.userservice.exception.BusinessException;
+import com.unear.userservice.exception.ErrorCode;
+
+public class CouponExpiredException extends BusinessException {
+    public CouponExpiredException() {
+        super(ErrorCode.COUPON_EXPIRED);
+    }
+    public CouponExpiredException(String message) {
+        super(ErrorCode.COUPON_EXPIRED, message);
+    }
+}

--- a/src/main/java/com/unear/userservice/exception/exception/CouponSoldOutException.java
+++ b/src/main/java/com/unear/userservice/exception/exception/CouponSoldOutException.java
@@ -1,0 +1,13 @@
+package com.unear.userservice.exception.exception;
+
+import com.unear.userservice.exception.BusinessException;
+import com.unear.userservice.exception.ErrorCode;
+
+public class CouponSoldOutException extends BusinessException {
+    public CouponSoldOutException() {
+        super(ErrorCode.COUPON_SOLD_OUT);
+    }
+    public CouponSoldOutException(String message) {
+        super(ErrorCode.COUPON_SOLD_OUT, message);
+    }
+}

--- a/src/main/java/com/unear/userservice/exception/exception/CouponTemplateNotFoundException.java
+++ b/src/main/java/com/unear/userservice/exception/exception/CouponTemplateNotFoundException.java
@@ -1,0 +1,14 @@
+package com.unear.userservice.exception.exception;
+
+import com.unear.userservice.exception.BusinessException;
+import com.unear.userservice.exception.ErrorCode;
+
+
+public class CouponTemplateNotFoundException extends BusinessException {
+    public CouponTemplateNotFoundException() {
+        super(ErrorCode.COUPON_TEMPLATE_NOT_FOUND);
+    }
+    public CouponTemplateNotFoundException(String message) {
+        super(ErrorCode.COUPON_TEMPLATE_NOT_FOUND, message);
+    }
+}


### PR DESCRIPTION
## PR 목적

- 쿠폰 템플릿 id로 쿠폰 다운로드, 현재 로그인한 사용자의 id를 기준으로 user_coupons 테이블에 저장
- 쿠폰 다운로드시 고유 바코드 번호 생성
- 매우 희박한 확률이지만, 바코드 중복 생성된 경우, 최대 3번까지 시도

## 변경 사항

  - [WL7-52] 쿠폰 다운로드

## 주요 구현 내용

- 쿠폰 템플릿 id로 쿠폰 다운로드 api 추가
- 쿠폰 다운로드시 중복 검사 및 다운받은 쿠폰의 바코드 번호 생성
- 바코드 생성시 중복이라면, 최대 3번까지 반복 수행
- CouponStatus Enum 추가
- 쿠폰 다운로드 관련 예외 추가
- user_coupons 테이블 user_id + coupon_template_id 조합 Unique 제약 추가
- 유효기간 검증 로직 추가

## 테스트 및 동작 화면 (필요 시 첨부)

- 쿠폰 다운로드 성공시, 바코드 번호와 함께 쿠폰 정보 반환
<img width="343" height="228" alt="스크린샷 2025-07-17 오후 5 10 39" src="https://github.com/user-attachments/assets/ca2d303c-a890-4c1d-b954-5f4c89ef9efe" />


- 이미 다운로드한 쿠폰
<img width="339" height="112" alt="스크린샷 2025-07-17 오후 8 01 04" src="https://github.com/user-attachments/assets/74e3d64e-2d89-404e-adee-114eb53659cc" />


- 존재하지않는 쿠폰템플릿 id
<img width="343" height="114" alt="스크린샷 2025-07-17 오후 5 11 16" src="https://github.com/user-attachments/assets/04891dee-31f6-42c4-82d0-5434556b9117" />


- 유효기기간 외에 쿠폰 다운로드
<img width="315" height="109" alt="스크린샷 2025-07-17 오후 8 17 38" src="https://github.com/user-attachments/assets/f232588e-e3bb-4155-a8d8-4e88afe98a89" />


- 선착순 쿠폰 다운로드 성공시, 바코드 번호와 함께 쿠폰 정보 반환
<img width="333" height="222" alt="스크린샷 2025-07-17 오후 8 01 40" src="https://github.com/user-attachments/assets/f86f0d84-92a4-4a70-8a16-e4350d0dee4b" />


- 이미 다운로드한 선착순 쿠폰
<img width="340" height="117" alt="스크린샷 2025-07-17 오후 8 01 51" src="https://github.com/user-attachments/assets/0f491b0d-a1b0-48d0-aade-8d061b74b464" />



## 리뷰 시 중점적으로 봐야 할 부분

- 다운받은 쿠폰의 바코드 생성 로직
- 추후, coupon_templates의 remaining_quantity 락 적용 필요합니다 
- #33 

## 병합 전 체크리스트

- [v] 로컬 테스트 완료
- [v] Postman 테스트 포함
- [v] 코드래빗 리뷰 검토


[WL7-52]: https://lguplus20250120.atlassian.net/browse/WL7-52?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ