### PR TITLE
[Wl7-189] 프랜차이즈 이름으로 혜택 필터링

### DIFF
--- a/src/main/java/com/unear/userservice/benefit/dto/request/FranchiseDiscountPolicyRequestDto.java
+++ b/src/main/java/com/unear/userservice/benefit/dto/request/FranchiseDiscountPolicyRequestDto.java
@@ -14,4 +14,5 @@ public class FranchiseDiscountPolicyRequestDto {
     private int page = 0;
     private int size = 10;
     private String categoryCode;
+    private String franchiseName;
 }

--- a/src/main/java/com/unear/userservice/benefit/service/impl/DiscountPolicyServiceImpl.java
+++ b/src/main/java/com/unear/userservice/benefit/service/impl/DiscountPolicyServiceImpl.java
@@ -46,6 +46,11 @@ public class DiscountPolicyServiceImpl implements DiscountPolicyService {
             if (requestDto.getCategoryCode() != null && !requestDto.getCategoryCode().isBlank()) {
                 predicates.add(cb.equal(root.get("categoryCode"), requestDto.getCategoryCode()));
             }
+
+            if (requestDto.getFranchiseName() != null && !requestDto.getFranchiseName().isBlank()) {
+                predicates.add(cb.like(cb.lower(root.get("name")), "%" + requestDto.getFranchiseName().toLowerCase() + "%"));
+            }
+
             return cb.and(predicates.toArray(new Predicate[0]));
         };
 


### PR DESCRIPTION
## PR 목적

- 기존 프랜차이즈 혜택 리스트 조회에, 이름으로 필터링하는 조건 추가


## 변경 사항

- [#34] 


## 주요 구현 내용

- FranchiseDiscountPolicyRequestDto 필터링 조건 dto에 franchiseName 추가
- DiscountPolicyServiceImpl 프랜차이즈 이름 필터링 로직 추가


## 테스트 및 동작 화면 (필요 시 첨부)

- 프랜차이즈 이름으로 필터링하여 리스트 조회
<img width="366" height="905" alt="스크린샷 2025-07-18 오전 10 16 37" src="https://github.com/user-attachments/assets/0ffd2ded-dfb8-4e16-971b-e7cc90e1dbac" />



## 리뷰 시 중점적으로 봐야 할 부분


## 병합 전 체크리스트

- [v] 로컬 테스트 완료
- [v] Postman 테스트 포함
- [ ] 코드래빗 리뷰 검토
