### PR TITLE
[Wl7-140] 즐겨찾기 장소 리스트 / 다운받은 쿠폰 리스트 조회

### DIFF
--- a/src/main/java/com/unear/userservice/coupon/controller/CouponController.java
+++ b/src/main/java/com/unear/userservice/coupon/controller/CouponController.java
@@ -7,7 +7,6 @@ import com.unear.userservice.coupon.dto.response.CouponResponseDto;
 import com.unear.userservice.coupon.dto.response.UserCouponResponseDto;
 import com.unear.userservice.coupon.service.CouponService;
 import com.unear.userservice.exception.exception.UnauthorizedException;
-import com.unear.userservice.exception.exception.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;

--- a/src/main/java/com/unear/userservice/coupon/controller/CouponController.java
+++ b/src/main/java/com/unear/userservice/coupon/controller/CouponController.java
@@ -6,6 +6,8 @@ import com.unear.userservice.common.security.CustomUser;
 import com.unear.userservice.coupon.dto.response.CouponResponseDto;
 import com.unear.userservice.coupon.dto.response.UserCouponResponseDto;
 import com.unear.userservice.coupon.service.CouponService;
+import com.unear.userservice.exception.exception.UnauthorizedException;
+import com.unear.userservice.exception.exception.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -55,12 +57,13 @@ public class CouponController {
     public ResponseEntity<ApiResponse<List<UserCouponResponseDto>>> getMyCoupons(
             @AuthenticationPrincipal CustomUser user
     ) {
-        Long userId = (user != null && user.getUser() != null) ? user.getUser().getUserId() : null;
+        if (user == null || user.getUser() == null) {
+            throw new UnauthorizedException("인증되지 않은 사용자입니다.");
+        }
+        Long userId = user.getUser().getUserId();
         List<UserCouponResponseDto> response = couponService.getMyCoupons(userId);
         return ResponseEntity.ok(ApiResponse.success("사용자 쿠폰 목록 조회 성공", response));
     }
-
-
 
 }
 

--- a/src/main/java/com/unear/userservice/coupon/controller/CouponController.java
+++ b/src/main/java/com/unear/userservice/coupon/controller/CouponController.java
@@ -51,6 +51,17 @@ public class CouponController {
         return ResponseEntity.ok(ApiResponse.success("쿠폰 다운로드 성공", response));
     }
 
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<List<UserCouponResponseDto>>> getMyCoupons(
+            @AuthenticationPrincipal CustomUser user
+    ) {
+        Long userId = (user != null && user.getUser() != null) ? user.getUser().getUserId() : null;
+        List<UserCouponResponseDto> response = couponService.getMyCoupons(userId);
+        return ResponseEntity.ok(ApiResponse.success("사용자 쿠폰 목록 조회 성공", response));
+    }
+
+
+
 }
 
 

--- a/src/main/java/com/unear/userservice/coupon/controller/CouponController.java
+++ b/src/main/java/com/unear/userservice/coupon/controller/CouponController.java
@@ -37,7 +37,10 @@ public class CouponController {
             @PathVariable Long couponTemplateId,
             @AuthenticationPrincipal CustomUser user
     ) {
-        Long userId = (user != null && user.getUser() != null) ? user.getUser().getUserId() : null;
+        if (user == null || user.getUser() == null) {
+            throw new UnauthorizedException("인증되지 않은 사용자입니다.");
+        }
+        Long userId = user.getUser().getUserId();
         UserCouponResponseDto response = couponService.downloadCoupon(userId, couponTemplateId);
         return ResponseEntity.ok(ApiResponse.success("쿠폰 다운로드 성공", response));
     }
@@ -47,7 +50,10 @@ public class CouponController {
             @PathVariable Long couponTemplateId,
             @AuthenticationPrincipal CustomUser user
     ) {
-        Long userId = (user != null && user.getUser() != null) ? user.getUser().getUserId() : null;
+        if (user == null || user.getUser() == null) {
+            throw new UnauthorizedException("인증되지 않은 사용자입니다.");
+        }
+        Long userId = user.getUser().getUserId();
         UserCouponResponseDto response = couponService.downloadFCFSCoupon(userId, couponTemplateId);
         return ResponseEntity.ok(ApiResponse.success("쿠폰 다운로드 성공", response));
     }

--- a/src/main/java/com/unear/userservice/coupon/dto/response/UserCouponResponseDto.java
+++ b/src/main/java/com/unear/userservice/coupon/dto/response/UserCouponResponseDto.java
@@ -14,6 +14,7 @@ public class UserCouponResponseDto {
     private String barcodeNumber;
     private String couponStatusCode;
     private LocalDate createdAt;
+    private LocalDate couponEnd;
 
     public static UserCouponResponseDto from(UserCoupon userCoupon) {
         return UserCouponResponseDto.builder()
@@ -24,6 +25,9 @@ public class UserCouponResponseDto {
                 .barcodeNumber(userCoupon.getBarcodeNumber())
                 .couponStatusCode(userCoupon.getCouponStatusCode())
                 .createdAt(userCoupon.getCreatedAt())
+                .couponEnd(userCoupon.getCouponTemplate() != null
+                        ? userCoupon.getCouponTemplate().getCouponEnd()
+                        : null)
                 .build();
     }
 }

--- a/src/main/java/com/unear/userservice/coupon/repository/UserCouponRepository.java
+++ b/src/main/java/com/unear/userservice/coupon/repository/UserCouponRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Set;
 
 public interface UserCouponRepository extends JpaRepository<UserCoupon, Long> {
@@ -17,5 +18,7 @@ public interface UserCouponRepository extends JpaRepository<UserCoupon, Long> {
     Set<Long> findCouponTemplateIdsByUserId(@Param("userId") Long userId);
 
     boolean existsByBarcodeNumber(String barcodeNumber);
+
+    List<UserCoupon> findByUser_UserId(Long userId);
 
 }

--- a/src/main/java/com/unear/userservice/coupon/service/CouponService.java
+++ b/src/main/java/com/unear/userservice/coupon/service/CouponService.java
@@ -13,4 +13,6 @@ public interface CouponService {
 
     UserCouponResponseDto downloadFCFSCoupon(Long userId, Long couponTemplateId);
 
+    List<UserCouponResponseDto> getMyCoupons(Long userId);
+
 }

--- a/src/main/java/com/unear/userservice/coupon/service/impl/CouponServiceImpl.java
+++ b/src/main/java/com/unear/userservice/coupon/service/impl/CouponServiceImpl.java
@@ -139,6 +139,9 @@ public class CouponServiceImpl implements CouponService {
 
     @Override
     public List<UserCouponResponseDto> getMyCoupons(Long userId) {
+        userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
+
         List<UserCoupon> userCoupons = userCouponRepository.findByUser_UserId(userId);
         return userCoupons.stream()
                 .map(UserCouponResponseDto::from)

--- a/src/main/java/com/unear/userservice/coupon/service/impl/CouponServiceImpl.java
+++ b/src/main/java/com/unear/userservice/coupon/service/impl/CouponServiceImpl.java
@@ -137,6 +137,14 @@ public class CouponServiceImpl implements CouponService {
     }
 
 
+    @Override
+    public List<UserCouponResponseDto> getMyCoupons(Long userId) {
+        List<UserCoupon> userCoupons = userCouponRepository.findByUser_UserId(userId);
+        return userCoupons.stream()
+                .map(UserCouponResponseDto::from)
+                .toList();
+    }
+
 
     private String generateUniqueBarcode() {
         for (int i = 0; i < 3; i++) {

--- a/src/main/java/com/unear/userservice/exception/ErrorCode.java
+++ b/src/main/java/com/unear/userservice/exception/ErrorCode.java
@@ -25,7 +25,8 @@ public enum ErrorCode {
     COUPON_ALREADY_DOWNLOADED(HttpStatus.BAD_REQUEST, "COUPON_ALREADY_DOWNLOADED", "이미 다운로드한 쿠폰입니다."),
     DUPLICATED_BARCODE(HttpStatus.BAD_REQUEST, "DUPLICATED_BARCODE" , "중복된 바코드 번호입니다."),
     COUPON_SOLD_OUT(HttpStatus.BAD_REQUEST, "COUPON_SOLD_OUT" , "쿠폰 재고가 없습니다."),
-    COUPON_EXPIRED(HttpStatus.BAD_REQUEST, "COUPON_EXPIRED", "유효 기간이 지난 쿠폰입니다.")
+    COUPON_EXPIRED(HttpStatus.BAD_REQUEST, "COUPON_EXPIRED", "유효 기간이 지난 쿠폰입니다."),
+    UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED_USER", "인증되지 않은 사용자입니다.")
     ;
 
 

--- a/src/main/java/com/unear/userservice/exception/exception/UnauthorizedException.java
+++ b/src/main/java/com/unear/userservice/exception/exception/UnauthorizedException.java
@@ -1,0 +1,14 @@
+package com.unear.userservice.exception.exception;
+
+import com.unear.userservice.exception.BusinessException;
+import com.unear.userservice.exception.ErrorCode;
+
+public class UnauthorizedException extends BusinessException {
+  public UnauthorizedException() {
+    super(ErrorCode.UNAUTHORIZED_USER);
+  }
+
+  public UnauthorizedException(String message) {
+    super(ErrorCode.UNAUTHORIZED_USER, message);
+  }
+}

--- a/src/main/java/com/unear/userservice/place/controller/PlaceController.java
+++ b/src/main/java/com/unear/userservice/place/controller/PlaceController.java
@@ -51,6 +51,15 @@ public class PlaceController {
         return ResponseEntity.ok(ApiResponse.success("즐겨찾기 상태 변경 성공", isNowFavorite));
     }
 
+    @GetMapping("/favorite")
+    public ResponseEntity<ApiResponse<List<PlaceResponseDto>>> getFavoritePlaces(
+            @AuthenticationPrincipal CustomUser user
+    ) {
+        Long userId = (user != null && user.getUser() != null) ? user.getUser().getUserId() : null;
+        List<PlaceResponseDto> favorites = placeService.getUserFavoritePlaces(userId);
+        return ResponseEntity.ok(ApiResponse.success("즐겨찾기 장소 목록 조회 성공", favorites));
+    }
+
 
 }
 

--- a/src/main/java/com/unear/userservice/place/controller/PlaceController.java
+++ b/src/main/java/com/unear/userservice/place/controller/PlaceController.java
@@ -2,6 +2,7 @@ package com.unear.userservice.place.controller;
 
 import com.unear.userservice.common.response.ApiResponse;
 import com.unear.userservice.common.security.CustomUser;
+import com.unear.userservice.exception.exception.UnauthorizedException;
 import com.unear.userservice.place.dto.request.PlaceRequestDto;
 import com.unear.userservice.place.dto.response.PlaceRenderResponseDto;
 import com.unear.userservice.place.dto.response.PlaceResponseDto;
@@ -46,7 +47,10 @@ public class PlaceController {
             @PathVariable Long placeId,
             @AuthenticationPrincipal CustomUser user
     ) {
-        Long userId = (user != null && user.getUser() != null) ? user.getUser().getUserId() : null;
+        if (user == null || user.getUser() == null) {
+            throw new UnauthorizedException("인증되지 않은 사용자입니다.");
+        }
+        Long userId = user.getUser().getUserId();
         boolean isNowFavorite = placeService.toggleFavorite(userId, placeId);
         return ResponseEntity.ok(ApiResponse.success("즐겨찾기 상태 변경 성공", isNowFavorite));
     }
@@ -55,7 +59,10 @@ public class PlaceController {
     public ResponseEntity<ApiResponse<List<PlaceResponseDto>>> getFavoritePlaces(
             @AuthenticationPrincipal CustomUser user
     ) {
-        Long userId = (user != null && user.getUser() != null) ? user.getUser().getUserId() : null;
+        if (user == null || user.getUser() == null) {
+            throw new UnauthorizedException("인증되지 않은 사용자입니다.");
+        }
+        Long userId = user.getUser().getUserId();
         List<PlaceResponseDto> favorites = placeService.getUserFavoritePlaces(userId);
         return ResponseEntity.ok(ApiResponse.success("즐겨찾기 장소 목록 조회 성공", favorites));
     }

--- a/src/main/java/com/unear/userservice/place/repository/FavoritePlaceRepository.java
+++ b/src/main/java/com/unear/userservice/place/repository/FavoritePlaceRepository.java
@@ -5,6 +5,7 @@ import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -17,6 +18,15 @@ public interface FavoritePlaceRepository extends JpaRepository<FavoritePlace, Lo
     boolean existsByUser_UserIdAndPlace_PlaceIdAndIsFavoritedTrue(Long userId, Long placeId);
 
     Optional<FavoritePlace> findByUser_UserIdAndPlace_PlaceId(Long userId, Long placeId);
+
+    @Query("""
+        SELECT f
+        FROM FavoritePlace f
+        JOIN FETCH f.place p
+        LEFT JOIN FETCH p.franchise
+        WHERE f.user.userId = :userId AND f.isFavorited = true
+    """)
+    List<FavoritePlace> findWithPlaceAndFranchiseByUserId(@Param("userId") Long userId);
 
 
 }

--- a/src/main/java/com/unear/userservice/place/service/PlaceService.java
+++ b/src/main/java/com/unear/userservice/place/service/PlaceService.java
@@ -11,5 +11,5 @@ public interface PlaceService {
     List<PlaceRenderResponseDto> getFilteredPlaces(PlaceRequestDto requestDto, Long userId);
     PlaceResponseDto getPlaceDetailWithFavorite(Long placeId, Long userId);
     boolean toggleFavorite(Long userId, Long placeId);
-
+    List<PlaceResponseDto> getUserFavoritePlaces(Long userId);
 }

--- a/src/main/java/com/unear/userservice/place/service/impl/PlaceServiceImpl.java
+++ b/src/main/java/com/unear/userservice/place/service/impl/PlaceServiceImpl.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @AllArgsConstructor
@@ -88,6 +89,15 @@ public class PlaceServiceImpl implements PlaceService {
             favoritePlaceRepository.save(favorite);
             return true;
         }
+    }
+
+    @Override
+    public List<PlaceResponseDto> getUserFavoritePlaces(Long userId) {
+        List<FavoritePlace> favoritePlaces = favoritePlaceRepository.findWithPlaceAndFranchiseByUserId(userId);
+
+        return favoritePlaces.stream()
+                .map(fav -> PlaceResponseDto.from(fav.getPlace(), true))
+                .collect(Collectors.toList());
     }
 
 }


### PR DESCRIPTION
## PR 목적

- 즐겨찾기 장소 리스트 조회 
- 다운받은 쿠폰 리스트 조회
- 현재 로그인한 사용자 기준으로 조회
- 곧 만료 예정 쿠폰은 couponEnd 와 현재 날짜 기준으로 프론트에서 필터링 필요

## 변경 사항

- [#39]
- [#38] 


## 주요 구현 내용

- PlaceController -> 즐겨찾기 장소 리스트 조회 api 추가
- CouponController -> 다운받은 쿠폰 리스트 조회 api 추가
- UserCouponResponseDto -> couponEnd 필드 추가
- fetch join 으로 FavoritePlace → Place → Franchise 미리 로딩

## 테스트 및 동작 화면 (필요 시 첨부)

- 즐겨찾기 장소 리스트 조회
<img width="375" height="769" alt="스크린샷 2025-07-19 오후 5 12 11" src="https://github.com/user-attachments/assets/36d8c201-a1f4-4149-b26e-5fa6cca78da2" />

- 다운받은 쿠폰 조회
<img width="364" height="571" alt="스크린샷 2025-07-19 오후 5 12 59" src="https://github.com/user-attachments/assets/7dcc2951-049e-4ef2-8bb6-74faf11f5623" />


## 리뷰 시 중점적으로 봐야 할 부분

## 병합 전 체크리스트

- [v] 로컬 테스트 완료
- [v] Postman 테스트 포함
- [ ] 코드래빗 리뷰 검토
