### PR TITLE
[Wl7-270] 사용자 위치기반 가까운 장소 검색

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,10 @@ dependencies {
     // oauth2
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
+    // PostGIS
+    implementation 'org.hibernate.orm:hibernate-spatial'
+    implementation 'org.locationtech.jts:jts-core'
+
 
 }
 

--- a/src/main/java/com/unear/userservice/place/controller/PlaceController.java
+++ b/src/main/java/com/unear/userservice/place/controller/PlaceController.java
@@ -10,6 +10,7 @@ import com.unear.userservice.place.dto.response.PlaceRenderResponseDto;
 import com.unear.userservice.place.dto.response.PlaceResponseDto;
 import com.unear.userservice.place.entity.Place;
 import com.unear.userservice.place.service.PlaceService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -27,7 +28,7 @@ public class PlaceController {
     @GetMapping("/{placeId}")
     public ResponseEntity<ApiResponse<PlaceResponseDto>> getPlace(
             @PathVariable Long placeId,
-            @ModelAttribute NearbyPlaceRequestDto location,
+            @Valid @ModelAttribute NearbyPlaceRequestDto location,
             @AuthenticationPrincipal CustomUser user
     ) {
         Long userId = (user != null && user.getUser() != null) ? user.getUser().getUserId() : null;
@@ -48,7 +49,7 @@ public class PlaceController {
 
     @GetMapping("/nearby")
     public ResponseEntity<ApiResponse<List<NearestPlaceResponseDto>>> getNearbyPlaces(
-            @ModelAttribute NearbyPlaceRequestDto requestDto,
+            @Valid @ModelAttribute NearbyPlaceRequestDto requestDto,
             @AuthenticationPrincipal CustomUser user
     ) {
         Long userId = (user != null && user.getUser() != null) ? user.getUser().getUserId() : null;

--- a/src/main/java/com/unear/userservice/place/controller/PlaceController.java
+++ b/src/main/java/com/unear/userservice/place/controller/PlaceController.java
@@ -3,7 +3,9 @@ package com.unear.userservice.place.controller;
 import com.unear.userservice.common.response.ApiResponse;
 import com.unear.userservice.common.security.CustomUser;
 import com.unear.userservice.exception.exception.UnauthorizedException;
+import com.unear.userservice.place.dto.request.NearbyPlaceRequestDto;
 import com.unear.userservice.place.dto.request.PlaceRequestDto;
+import com.unear.userservice.place.dto.response.NearestPlaceResponseDto;
 import com.unear.userservice.place.dto.response.PlaceRenderResponseDto;
 import com.unear.userservice.place.dto.response.PlaceResponseDto;
 import com.unear.userservice.place.entity.Place;
@@ -25,10 +27,11 @@ public class PlaceController {
     @GetMapping("/{placeId}")
     public ResponseEntity<ApiResponse<PlaceResponseDto>> getPlace(
             @PathVariable Long placeId,
+            @ModelAttribute NearbyPlaceRequestDto location,
             @AuthenticationPrincipal CustomUser user
     ) {
         Long userId = (user != null && user.getUser() != null) ? user.getUser().getUserId() : null;
-        PlaceResponseDto dto = placeService.getPlaceDetailWithFavorite(placeId, userId);
+        PlaceResponseDto dto = placeService.getPlaceDetail(placeId, userId, location.getLatitude(), location.getLongitude());
         return ResponseEntity.ok(ApiResponse.success("장소 조회 성공",dto));
     }
 
@@ -41,6 +44,19 @@ public class PlaceController {
         List<PlaceRenderResponseDto> result = placeService.getFilteredPlaces(requestDto, userId);
         return ResponseEntity.ok(ApiResponse.success("장소 목록 조회 성공", result));
     }
+
+
+    @GetMapping("/nearby")
+    public ResponseEntity<ApiResponse<List<NearestPlaceResponseDto>>> getNearbyPlaces(
+            @ModelAttribute NearbyPlaceRequestDto requestDto,
+            @AuthenticationPrincipal CustomUser user
+    ) {
+        Long userId = (user != null && user.getUser() != null) ? user.getUser().getUserId() : null;
+        List<NearestPlaceResponseDto> result = placeService.getNearbyPlaces(requestDto, userId);
+        return ResponseEntity.ok(ApiResponse.success("주변 매장 조회 성공", result));
+    }
+
+
 
     @PostMapping("/{placeId}/favorite")
     public ResponseEntity<ApiResponse<Boolean>> toggleFavorite(

--- a/src/main/java/com/unear/userservice/place/dto/request/NearbyPlaceRequestDto.java
+++ b/src/main/java/com/unear/userservice/place/dto/request/NearbyPlaceRequestDto.java
@@ -1,12 +1,23 @@
 package com.unear.userservice.place.dto.request;
 
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
 public class NearbyPlaceRequestDto {
+
+    @NotNull(message = "위도는 필수입니다.")
+    @DecimalMin(value = "-90.0", inclusive = true, message = "위도는 -90 이상이어야 합니다.")
+    @DecimalMax(value = "90.0", inclusive = true, message = "위도는 90 이하이어야 합니다.")
     private Double latitude;
+
+    @NotNull(message = "경도는 필수입니다.")
+    @DecimalMin(value = "-180.0", inclusive = true, message = "경도는 -180 이상이어야 합니다.")
+    @DecimalMax(value = "180.0", inclusive = true, message = "경도는 180 이하이어야 합니다.")
     private Double longitude;
 }
 

--- a/src/main/java/com/unear/userservice/place/dto/request/NearbyPlaceRequestDto.java
+++ b/src/main/java/com/unear/userservice/place/dto/request/NearbyPlaceRequestDto.java
@@ -1,0 +1,12 @@
+package com.unear.userservice.place.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class NearbyPlaceRequestDto {
+    private Double latitude;
+    private Double longitude;
+}
+

--- a/src/main/java/com/unear/userservice/place/dto/response/NearestPlaceProjection.java
+++ b/src/main/java/com/unear/userservice/place/dto/response/NearestPlaceProjection.java
@@ -1,0 +1,6 @@
+package com.unear.userservice.place.dto.response;
+
+public interface NearestPlaceProjection {
+    Long getPlaceId();
+    Double getDistance();
+}

--- a/src/main/java/com/unear/userservice/place/dto/response/NearestPlaceResponseDto.java
+++ b/src/main/java/com/unear/userservice/place/dto/response/NearestPlaceResponseDto.java
@@ -1,0 +1,21 @@
+package com.unear.userservice.place.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class NearestPlaceResponseDto {
+    private Long placeId;
+    private Double distanceKm;
+
+    public static NearestPlaceResponseDto from(
+            NearestPlaceProjection p
+    ) {
+        return NearestPlaceResponseDto.builder()
+                .placeId(p.getPlaceId())
+                .distanceKm(Math.round(p.getDistance() / 100.0) / 10.0)
+                .build();
+    }
+}
+

--- a/src/main/java/com/unear/userservice/place/dto/response/PlaceResponseDto.java
+++ b/src/main/java/com/unear/userservice/place/dto/response/PlaceResponseDto.java
@@ -23,8 +23,9 @@ public class PlaceResponseDto {
     private String eventCode;
     private String franchiseName;
     private boolean isFavorite;
+    private Double distanceKm;
 
-    public static PlaceResponseDto from(Place place, boolean isFavorite) {
+    public static PlaceResponseDto from(Place place, boolean isFavorite, Double distanceKm) {
         return PlaceResponseDto.builder()
                 .placeId(place.getPlaceId())
                 .placeName(place.getPlaceName())
@@ -40,7 +41,12 @@ public class PlaceResponseDto {
                 .eventCode(place.getEventCode())
                 .franchiseName(place.getFranchise() != null ? place.getFranchise().getName() : null)
                 .isFavorite(isFavorite)
+                .distanceKm(distanceKm != null ? distanceKm : 0.0)
                 .build();
+    }
+
+    public static PlaceResponseDto from(Place place, boolean isFavorite) {
+        return from(place, isFavorite, null);
     }
 
 }

--- a/src/main/java/com/unear/userservice/place/dto/response/PlaceResponseDto.java
+++ b/src/main/java/com/unear/userservice/place/dto/response/PlaceResponseDto.java
@@ -41,7 +41,7 @@ public class PlaceResponseDto {
                 .eventCode(place.getEventCode())
                 .franchiseName(place.getFranchise() != null ? place.getFranchise().getName() : null)
                 .isFavorite(isFavorite)
-                .distanceKm(distanceKm != null ? distanceKm : 0.0)
+                .distanceKm(distanceKm)
                 .build();
     }
 

--- a/src/main/java/com/unear/userservice/place/entity/Place.java
+++ b/src/main/java/com/unear/userservice/place/entity/Place.java
@@ -4,6 +4,7 @@ import com.unear.userservice.benefit.entity.GeneralDiscountPolicy;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+import org.locationtech.jts.geom.Point;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -44,5 +45,9 @@ public class Place {
 
     @OneToMany(mappedBy = "place")
     private List<GeneralDiscountPolicy> discountPolicies = new ArrayList<>();
+
+    @Column(columnDefinition = "geography(Point, 4326)")
+    private Point location;
+
 }
 

--- a/src/main/java/com/unear/userservice/place/repository/PlaceRepository.java
+++ b/src/main/java/com/unear/userservice/place/repository/PlaceRepository.java
@@ -1,7 +1,9 @@
 package com.unear.userservice.place.repository;
 
+import com.unear.userservice.place.dto.response.NearestPlaceProjection;
 import com.unear.userservice.place.entity.Place;
 import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -14,23 +16,23 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
     Optional<Place> findById(Long id);
 
     @Query("""
-    SELECT p FROM Place p
-    LEFT JOIN FavoritePlace f 
-      ON f.place = p 
-      AND f.user.userId = :userId
-    WHERE (:categoryCode IS NULL OR p.categoryCode = :categoryCode)
-    AND (:benefitCategory IS NULL OR p.benefitCategory = :benefitCategory)
-    AND (
-      :isFavorite IS NULL
-      OR (:isFavorite = TRUE AND f.isFavorited = TRUE)
-      OR (:isFavorite = FALSE AND (f IS NULL OR f.isFavorited = FALSE))
-    )
-    AND (:southWestLatitude IS NULL OR p.latitude >= :southWestLatitude)
-    AND (:northEastLatitude IS NULL OR p.latitude <= :northEastLatitude)
-    AND (:southWestLongitude IS NULL OR p.longitude >= :southWestLongitude)
-    AND (:northEastLongitude IS NULL OR p.longitude <= :northEastLongitude)
-    AND (:keyword IS NULL OR LOWER(p.placeName) LIKE LOWER(CONCAT('%', :keyword, '%')))
-""")
+        SELECT p FROM Place p
+        LEFT JOIN FavoritePlace f 
+          ON f.place = p 
+          AND f.user.userId = :userId
+        WHERE (:categoryCode IS NULL OR p.categoryCode = :categoryCode)
+        AND (:benefitCategory IS NULL OR p.benefitCategory = :benefitCategory)
+        AND (
+          :isFavorite IS NULL
+          OR (:isFavorite = TRUE AND f.isFavorited = TRUE)
+          OR (:isFavorite = FALSE AND (f IS NULL OR f.isFavorited = FALSE))
+        )
+        AND (:southWestLatitude IS NULL OR p.latitude >= :southWestLatitude)
+        AND (:northEastLatitude IS NULL OR p.latitude <= :northEastLatitude)
+        AND (:southWestLongitude IS NULL OR p.longitude >= :southWestLongitude)
+        AND (:northEastLongitude IS NULL OR p.longitude <= :northEastLongitude)
+        AND (:keyword IS NULL OR LOWER(p.placeName) LIKE LOWER(CONCAT('%', :keyword, '%')))
+    """)
     List<Place> findFilteredPlaces(
             @Param("userId") Long userId,
             @Param("categoryCode") String categoryCode,
@@ -45,6 +47,29 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
 
     @Query("SELECT p.franchise.franchiseId FROM Place p WHERE p.placeId = :placeId")
     Optional<Long> findFranchiseIdByPlaceId(@Param("placeId") Long placeId);
+
+    @Query(value = """
+    SELECT 
+        place_id AS placeId,
+        ST_Distance(location, ST_MakePoint(:longitude, :latitude)::geography) AS distance
+    FROM places
+    ORDER BY distance
+    LIMIT :limit
+    """, nativeQuery = true)
+    List<NearestPlaceProjection> findNearestPlaceIdsByDistance(
+            @Param("latitude") double latitude,
+            @Param("longitude") double longitude,
+            @Param("limit") int limit
+    );
+
+    @Query(value = """
+        SELECT ST_Distance(location, ST_MakePoint(:longitude, :latitude) ::geography)
+        FROM places
+        WHERE place_id = :placeId
+    """, nativeQuery = true)
+    Double calculateDistance(@Param("placeId") Long placeId,
+                             @Param("latitude") Double latitude,
+                             @Param("longitude") Double longitude);
 
 
 }

--- a/src/main/java/com/unear/userservice/place/repository/PlaceRepository.java
+++ b/src/main/java/com/unear/userservice/place/repository/PlaceRepository.java
@@ -51,7 +51,7 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
     @Query(value = """
     SELECT 
         place_id AS placeId,
-        ST_Distance(location, ST_MakePoint(:longitude, :latitude)::geography) AS distance
+        ST_Distance(location, ST_SetSRID(ST_MakePoint(:longitude, :latitude), 4326)::geography) AS distance
     FROM places
     ORDER BY distance
     LIMIT :limit
@@ -65,7 +65,7 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
     @Query(value = """
     SELECT ST_Distance(
             location,
-            ST_MakePoint(:longitude, :latitude)::geography
+            ST_SetSRID(ST_MakePoint(:longitude, :latitude), 4326)::geography
         )
         FROM places
         WHERE place_id = :placeId

--- a/src/main/java/com/unear/userservice/place/service/PlaceService.java
+++ b/src/main/java/com/unear/userservice/place/service/PlaceService.java
@@ -1,6 +1,8 @@
 package com.unear.userservice.place.service;
 
+import com.unear.userservice.place.dto.request.NearbyPlaceRequestDto;
 import com.unear.userservice.place.dto.request.PlaceRequestDto;
+import com.unear.userservice.place.dto.response.NearestPlaceResponseDto;
 import com.unear.userservice.place.dto.response.PlaceRenderResponseDto;
 import com.unear.userservice.place.dto.response.PlaceResponseDto;
 
@@ -9,7 +11,8 @@ import java.util.List;
 public interface PlaceService {
 
     List<PlaceRenderResponseDto> getFilteredPlaces(PlaceRequestDto requestDto, Long userId);
-    PlaceResponseDto getPlaceDetailWithFavorite(Long placeId, Long userId);
+    PlaceResponseDto getPlaceDetail(Long placeId, Long userId, Double latitude, Double longitude);
     boolean toggleFavorite(Long userId, Long placeId);
     List<PlaceResponseDto> getUserFavoritePlaces(Long userId);
+    List<NearestPlaceResponseDto> getNearbyPlaces(NearbyPlaceRequestDto requestDto, Long userId);
 }


### PR DESCRIPTION
## PR 목적

- Place 엔티티에  PostGIS 공간 필드 location 추가
- GET /places/nearby 근처 5개 장소 { place_id , distanceKm } 형태로 반환하는 api 추가
- 기존 GET /places/{place_id}에 distanceKm 필드 포함하여 반환하도록 수정

## 변경 사항

- [#45]


## 주요 구현 내용

- PostGIS 의존성 추가
- Place 엔티티 Point location 필드 추가 및 인덱스 생성
- PostGIS 공간 필드 사용한 거리 계산용 쿼리 추가
- 거리 계산 저장하는 NearestPlaceProjection 추가
- PlaceResponseDto from -> distanceKm 유무에 따라 메서드 오버로딩
- 사용자 위치 기반으로 가까운 장소 5개 반환하는 api 추가
- PlaceResponseDto 에 distanceKm 필드 추가
- findFilteredPlaces -> nativeQuery로 수정


## 테스트 및 동작 화면 (필요 시 첨부)

- 사용자 기준 가까운 장소 리스트 조회
<img width="291" height="495" alt="스크린샷 2025-07-20 오후 2 55 52" src="https://github.com/user-attachments/assets/5d4fc555-0c42-41e8-a8c0-de72a8415120" />

- id로 장소 상세조회 -> distanceKm 추가
<img width="353" height="430" alt="스크린샷 2025-07-20 오후 2 56 29" src="https://github.com/user-attachments/assets/107a0932-40b8-49e8-aa7e-df40db51f6e4" />



## 리뷰 시 중점적으로 봐야 할 부분

- 즐겨찾기 리스트 조회시, distanceKm 필요하면 추가 가능


## 병합 전 체크리스트

- [v] 로컬 테스트 완료
- [v] Postman 테스트 포함
- [v] 코드래빗 리뷰 검토
