### PR TITLE
[Wl7-306] 다운받은 쿠폰 상세 조회

### DIFF
--- a/src/main/java/com/unear/userservice/coupon/controller/CouponController.java
+++ b/src/main/java/com/unear/userservice/coupon/controller/CouponController.java
@@ -5,6 +5,7 @@ import com.unear.userservice.common.response.ApiResponse;
 import com.unear.userservice.common.security.CustomUser;
 import com.unear.userservice.coupon.dto.response.CouponResponseDto;
 import com.unear.userservice.coupon.dto.response.UserCouponResponseDto;
+import com.unear.userservice.coupon.dto.response.UserCouponResponseListDto;
 import com.unear.userservice.coupon.service.CouponService;
 import com.unear.userservice.exception.exception.UnauthorizedException;
 import lombok.RequiredArgsConstructor;
@@ -59,14 +60,14 @@ public class CouponController {
     }
 
     @GetMapping("/me")
-    public ResponseEntity<ApiResponse<List<UserCouponResponseDto>>> getMyCoupons(
+    public ResponseEntity<ApiResponse<UserCouponResponseListDto>> getMyCoupons(
             @AuthenticationPrincipal CustomUser user
     ) {
         if (user == null || user.getUser() == null) {
             throw new UnauthorizedException("인증되지 않은 사용자입니다.");
         }
         Long userId = user.getUser().getUserId();
-        List<UserCouponResponseDto> response = couponService.getMyCoupons(userId);
+        UserCouponResponseListDto response = couponService.getMyCoupons(userId);
         return ResponseEntity.ok(ApiResponse.success("사용자 쿠폰 목록 조회 성공", response));
     }
 

--- a/src/main/java/com/unear/userservice/coupon/controller/CouponController.java
+++ b/src/main/java/com/unear/userservice/coupon/controller/CouponController.java
@@ -70,6 +70,20 @@ public class CouponController {
         return ResponseEntity.ok(ApiResponse.success("사용자 쿠폰 목록 조회 성공", response));
     }
 
+    @GetMapping("/me/{userCouponId}")
+    public ResponseEntity<ApiResponse<UserCouponResponseDto>> getMyCouponDetail(
+            @PathVariable Long userCouponId,
+            @AuthenticationPrincipal CustomUser user
+    ) {
+        if (user == null || user.getUser() == null) {
+            throw new UnauthorizedException("인증되지 않은 사용자입니다.");
+        }
+        Long userId = user.getUser().getUserId();
+        UserCouponResponseDto response = couponService.getMyCouponDetail(userId, userCouponId);
+        return ResponseEntity.ok(ApiResponse.success("사용자 쿠폰 상세 조회 성공", response));
+    }
+
+
 }
 
 

--- a/src/main/java/com/unear/userservice/coupon/dto/response/UserCouponResponseListDto.java
+++ b/src/main/java/com/unear/userservice/coupon/dto/response/UserCouponResponseListDto.java
@@ -1,0 +1,19 @@
+package com.unear.userservice.coupon.dto.response;
+
+
+import lombok.Getter;
+
+import java.util.List;
+
+
+@Getter
+public class UserCouponResponseListDto {
+    private int count;
+    private List<UserCouponResponseDto> coupons;
+
+    public UserCouponResponseListDto(List<UserCouponResponseDto> coupons) {
+        this.count = coupons.size();
+        this.coupons = coupons;
+    }
+
+}

--- a/src/main/java/com/unear/userservice/coupon/repository/UserCouponRepository.java
+++ b/src/main/java/com/unear/userservice/coupon/repository/UserCouponRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 public interface UserCouponRepository extends JpaRepository<UserCoupon, Long> {
@@ -20,5 +21,8 @@ public interface UserCouponRepository extends JpaRepository<UserCoupon, Long> {
     boolean existsByBarcodeNumber(String barcodeNumber);
 
     List<UserCoupon> findByUser_UserId(Long userId);
+
+    Optional<UserCoupon> findByUserCouponIdAndUser_UserId(Long userCouponId, Long userId);
+
 
 }

--- a/src/main/java/com/unear/userservice/coupon/service/CouponService.java
+++ b/src/main/java/com/unear/userservice/coupon/service/CouponService.java
@@ -15,4 +15,6 @@ public interface CouponService {
 
     List<UserCouponResponseDto> getMyCoupons(Long userId);
 
+    UserCouponResponseDto getMyCouponDetail(Long userId, Long userCouponId);
+
 }

--- a/src/main/java/com/unear/userservice/coupon/service/CouponService.java
+++ b/src/main/java/com/unear/userservice/coupon/service/CouponService.java
@@ -2,6 +2,7 @@ package com.unear.userservice.coupon.service;
 
 import com.unear.userservice.coupon.dto.response.CouponResponseDto;
 import com.unear.userservice.coupon.dto.response.UserCouponResponseDto;
+import com.unear.userservice.coupon.dto.response.UserCouponResponseListDto;
 
 import java.util.List;
 
@@ -13,7 +14,7 @@ public interface CouponService {
 
     UserCouponResponseDto downloadFCFSCoupon(Long userId, Long couponTemplateId);
 
-    List<UserCouponResponseDto> getMyCoupons(Long userId);
+    UserCouponResponseListDto getMyCoupons(Long userId);
 
     UserCouponResponseDto getMyCouponDetail(Long userId, Long userCouponId);
 

--- a/src/main/java/com/unear/userservice/coupon/service/impl/CouponServiceImpl.java
+++ b/src/main/java/com/unear/userservice/coupon/service/impl/CouponServiceImpl.java
@@ -149,6 +149,14 @@ public class CouponServiceImpl implements CouponService {
     }
 
 
+    @Override
+    public UserCouponResponseDto getMyCouponDetail(Long userId, Long userCouponId) {
+        UserCoupon coupon = userCouponRepository.findByUserCouponIdAndUser_UserId(userCouponId, userId)
+                .orElseThrow(() -> new CouponTemplateNotFoundException("해당 쿠폰을 찾을 수 없습니다."));
+        return UserCouponResponseDto.from(coupon);
+    }
+
+
     private String generateUniqueBarcode() {
         for (int i = 0; i < 3; i++) {
             String barcode = generateBarcode();

--- a/src/main/java/com/unear/userservice/coupon/service/impl/CouponServiceImpl.java
+++ b/src/main/java/com/unear/userservice/coupon/service/impl/CouponServiceImpl.java
@@ -7,6 +7,7 @@ import com.unear.userservice.common.enums.DiscountPolicy;
 import com.unear.userservice.common.enums.PlaceType;
 import com.unear.userservice.coupon.dto.response.CouponResponseDto;
 import com.unear.userservice.coupon.dto.response.UserCouponResponseDto;
+import com.unear.userservice.coupon.dto.response.UserCouponResponseListDto;
 import com.unear.userservice.coupon.entity.CouponTemplate;
 import com.unear.userservice.coupon.entity.UserCoupon;
 import com.unear.userservice.coupon.repository.CouponTemplateRepository;
@@ -138,15 +139,19 @@ public class CouponServiceImpl implements CouponService {
 
 
     @Override
-    public List<UserCouponResponseDto> getMyCoupons(Long userId) {
+    public UserCouponResponseListDto getMyCoupons(Long userId) {
         userRepository.findById(userId)
                 .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
 
         List<UserCoupon> userCoupons = userCouponRepository.findByUser_UserId(userId);
-        return userCoupons.stream()
+
+        List<UserCouponResponseDto> dtoList = userCoupons.stream()
                 .map(UserCouponResponseDto::from)
                 .toList();
+
+        return new UserCouponResponseListDto(dtoList);
     }
+
 
 
     @Override

--- a/src/main/java/com/unear/userservice/place/dto/response/PlaceRenderResponseDto.java
+++ b/src/main/java/com/unear/userservice/place/dto/response/PlaceRenderResponseDto.java
@@ -27,7 +27,7 @@ public class PlaceRenderResponseDto {
                 .longitude(place.getLongitude())
                 .categoryCode(place.getCategoryCode())
                 .markerCode(place.getMarkerCode())
-                .eventCode(place.getEventCode())
+                .eventCode(place.getEventTypeCode())
                 .benefitCategory(place.getBenefitCategory())
                 .favorite(isFavorite)
                 .build();

--- a/src/main/java/com/unear/userservice/place/dto/response/PlaceResponseDto.java
+++ b/src/main/java/com/unear/userservice/place/dto/response/PlaceResponseDto.java
@@ -38,7 +38,7 @@ public class PlaceResponseDto {
                 .endTime(place.getEndTime())
                 .categoryCode(place.getCategoryCode())
                 .markerCode(place.getMarkerCode())
-                .eventCode(place.getEventCode())
+                .eventCode(place.getEventTypeCode())
                 .franchiseName(place.getFranchise() != null ? place.getFranchise().getName() : null)
                 .isFavorite(isFavorite)
                 .distanceKm(distanceKm)

--- a/src/main/java/com/unear/userservice/place/entity/Place.java
+++ b/src/main/java/com/unear/userservice/place/entity/Place.java
@@ -34,7 +34,7 @@ public class Place {
     private Integer endTime;
     private String categoryCode;
     private String markerCode;
-    private String eventCode;
+    private String eventTypeCode;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "franchise_id")


### PR DESCRIPTION
## PR 목적

- user_coupon_id로 다운받은 쿠폰 상세조회 api 추가
- 기존 다운받은 쿠폰 리스트 조회 api에 count 정보 추가

## 변경 사항

- [#59]
- [#56]


## 주요 구현 내용

- GET /coupons/me/{user_coupon_id} -> user_coupon_id로 다운받은 쿠폰 상세조회 api 
- GET /coupons/me 반환 타입 UserCouponResponseListDto로 수정
- Place 엔티티 eventCode -> eventTypeCode로 수정

## 테스트 및 동작 화면 (필요 시 첨부)

- user_coupon_id로 다운받은 쿠폰 상세조회
<img width="335" height="243" alt="스크린샷 2025-07-21 오후 2 52 22" src="https://github.com/user-attachments/assets/1c34e9b1-2cac-4209-b1b9-9646337ffa5c" />

- 다운받은 쿠폰 리스트 조회 ( count 필드 추가 )
<img width="373" height="675" alt="스크린샷 2025-07-21 오후 2 52 47" src="https://github.com/user-attachments/assets/f3dd5d98-180e-4a7a-8345-93261612a332" />


## 리뷰 시 중점적으로 봐야 할 부분

## 병합 전 체크리스트

- [v] 로컬 테스트 완료
- [v] Postman 테스트 포함
- [v] 코드래빗 리뷰 검토
