### PR TITLE
[Wl7-306] 쿠폰 상세 정보 조회

### DIFF
--- a/src/main/java/com/unear/userservice/benefit/dto/response/GeneralDiscountPolicyDetailResponseDto.java
+++ b/src/main/java/com/unear/userservice/benefit/dto/response/GeneralDiscountPolicyDetailResponseDto.java
@@ -16,8 +16,8 @@ public class GeneralDiscountPolicyDetailResponseDto {
     private Integer endTime;
 
     private Integer unitBaseAmount;
-    private Integer discountValue;
-    private Integer percent;
+    private Integer fixedDiscount;
+    private Integer discountPercent;
     private Integer minPurchaseAmount;
     private Integer maxDiscountAmount;
 
@@ -35,8 +35,8 @@ public class GeneralDiscountPolicyDetailResponseDto {
                 .startTime(place.getStartTime())
                 .endTime(place.getEndTime())
                 .unitBaseAmount(detail.getUnitBaseAmount())
-                .discountValue(detail.getDiscountValue())
-                .percent(detail.getPercent())
+                .fixedDiscount(detail.getFixedDiscount())
+                .discountPercent(detail.getDiscountPercent())
                 .minPurchaseAmount(detail.getMinPurchaseAmount())
                 .maxDiscountAmount(detail.getMaxDiscountAmount())
                 .discountCode(detail.getDiscountCode())

--- a/src/main/java/com/unear/userservice/benefit/entity/GeneralDiscountPolicy.java
+++ b/src/main/java/com/unear/userservice/benefit/entity/GeneralDiscountPolicy.java
@@ -20,8 +20,8 @@ public class GeneralDiscountPolicy {
     private Place place;
 
     private Integer unitBaseAmount;
-    private Integer discountValue;
-    private Integer percent;
+    private Integer fixedDiscount;
+    private Integer discountPercent;
     private Integer minPurchaseAmount;
     private Integer maxDiscountAmount;
 

--- a/src/main/java/com/unear/userservice/coupon/controller/CouponController.java
+++ b/src/main/java/com/unear/userservice/coupon/controller/CouponController.java
@@ -1,6 +1,4 @@
 package com.unear.userservice.coupon.controller;
-
-
 import com.unear.userservice.common.response.ApiResponse;
 import com.unear.userservice.common.security.CustomUser;
 import com.unear.userservice.coupon.dto.response.CouponResponseDto;

--- a/src/main/java/com/unear/userservice/coupon/controller/CouponController.java
+++ b/src/main/java/com/unear/userservice/coupon/controller/CouponController.java
@@ -4,8 +4,8 @@ package com.unear.userservice.coupon.controller;
 import com.unear.userservice.common.response.ApiResponse;
 import com.unear.userservice.common.security.CustomUser;
 import com.unear.userservice.coupon.dto.response.CouponResponseDto;
+import com.unear.userservice.coupon.dto.response.UserCouponListResponseDto;
 import com.unear.userservice.coupon.dto.response.UserCouponResponseDto;
-import com.unear.userservice.coupon.dto.response.UserCouponResponseListDto;
 import com.unear.userservice.coupon.service.CouponService;
 import com.unear.userservice.exception.exception.UnauthorizedException;
 import lombok.RequiredArgsConstructor;
@@ -60,14 +60,14 @@ public class CouponController {
     }
 
     @GetMapping("/me")
-    public ResponseEntity<ApiResponse<UserCouponResponseListDto>> getMyCoupons(
+    public ResponseEntity<ApiResponse<UserCouponListResponseDto>> getMyCoupons(
             @AuthenticationPrincipal CustomUser user
     ) {
         if (user == null || user.getUser() == null) {
             throw new UnauthorizedException("인증되지 않은 사용자입니다.");
         }
         Long userId = user.getUser().getUserId();
-        UserCouponResponseListDto response = couponService.getMyCoupons(userId);
+        UserCouponListResponseDto response = couponService.getMyCoupons(userId);
         return ResponseEntity.ok(ApiResponse.success("사용자 쿠폰 목록 조회 성공", response));
     }
 

--- a/src/main/java/com/unear/userservice/coupon/controller/CouponController.java
+++ b/src/main/java/com/unear/userservice/coupon/controller/CouponController.java
@@ -4,6 +4,7 @@ package com.unear.userservice.coupon.controller;
 import com.unear.userservice.common.response.ApiResponse;
 import com.unear.userservice.common.security.CustomUser;
 import com.unear.userservice.coupon.dto.response.CouponResponseDto;
+import com.unear.userservice.coupon.dto.response.UserCouponDetailResponseDto;
 import com.unear.userservice.coupon.dto.response.UserCouponListResponseDto;
 import com.unear.userservice.coupon.dto.response.UserCouponResponseDto;
 import com.unear.userservice.coupon.service.CouponService;
@@ -72,7 +73,7 @@ public class CouponController {
     }
 
     @GetMapping("/me/{userCouponId}")
-    public ResponseEntity<ApiResponse<UserCouponResponseDto>> getMyCouponDetail(
+    public ResponseEntity<ApiResponse<UserCouponDetailResponseDto>> getMyCouponDetail(
             @PathVariable Long userCouponId,
             @AuthenticationPrincipal CustomUser user
     ) {
@@ -80,9 +81,10 @@ public class CouponController {
             throw new UnauthorizedException("인증되지 않은 사용자입니다.");
         }
         Long userId = user.getUser().getUserId();
-        UserCouponResponseDto response = couponService.getMyCouponDetail(userId, userCouponId);
+        UserCouponDetailResponseDto response = couponService.getMyCouponDetail(userId, userCouponId);
         return ResponseEntity.ok(ApiResponse.success("사용자 쿠폰 상세 조회 성공", response));
     }
+
 
 
 }

--- a/src/main/java/com/unear/userservice/coupon/dto/response/CouponResponseDto.java
+++ b/src/main/java/com/unear/userservice/coupon/dto/response/CouponResponseDto.java
@@ -4,8 +4,7 @@ import com.unear.userservice.coupon.entity.CouponTemplate;
 import lombok.Builder;
 import lombok.Getter;
 
-
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Getter
 @Builder
@@ -16,8 +15,8 @@ public class CouponResponseDto {
     private String discountCode;
     private String membershipCode;
     private String discountInfo;
-    private LocalDate couponStart;
-    private LocalDate couponEnd;
+    private LocalDateTime couponStart;
+    private LocalDateTime couponEnd;
 
     private boolean isDownloaded;
 

--- a/src/main/java/com/unear/userservice/coupon/dto/response/UserCouponDetailResponseDto.java
+++ b/src/main/java/com/unear/userservice/coupon/dto/response/UserCouponDetailResponseDto.java
@@ -3,7 +3,6 @@ package com.unear.userservice.coupon.dto.response;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Getter

--- a/src/main/java/com/unear/userservice/coupon/dto/response/UserCouponDetailResponseDto.java
+++ b/src/main/java/com/unear/userservice/coupon/dto/response/UserCouponDetailResponseDto.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Getter
 @Builder
@@ -13,8 +14,8 @@ public class UserCouponDetailResponseDto {
     private String couponName;
     private String barcodeNumber;
     private String couponStatusCode;
-    private LocalDate createdAt;
-    private LocalDate couponEnd;
+    private LocalDateTime createdAt;
+    private LocalDateTime couponEnd;
 
     private String discountCode;
     private String membershipCode;

--- a/src/main/java/com/unear/userservice/coupon/dto/response/UserCouponDetailResponseDto.java
+++ b/src/main/java/com/unear/userservice/coupon/dto/response/UserCouponDetailResponseDto.java
@@ -1,0 +1,29 @@
+package com.unear.userservice.coupon.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class UserCouponDetailResponseDto {
+
+    private Long userCouponId;
+    private String couponName;
+    private String barcodeNumber;
+    private String couponStatusCode;
+    private LocalDate createdAt;
+    private LocalDate couponEnd;
+
+    private String discountCode;
+    private String membershipCode;
+    private Integer unitBaseAmount;
+    private Integer fixedDiscount;
+    private Integer discountPercent;
+    private Integer minPurchaseAmount;
+    private Integer maxDiscountAmount;
+
+    private String markerCode;
+}
+

--- a/src/main/java/com/unear/userservice/coupon/dto/response/UserCouponListResponseDto.java
+++ b/src/main/java/com/unear/userservice/coupon/dto/response/UserCouponListResponseDto.java
@@ -7,11 +7,11 @@ import java.util.List;
 
 
 @Getter
-public class UserCouponResponseListDto {
+public class UserCouponListResponseDto {
     private int count;
     private List<UserCouponResponseDto> coupons;
 
-    public UserCouponResponseListDto(List<UserCouponResponseDto> coupons) {
+    public UserCouponListResponseDto(List<UserCouponResponseDto> coupons) {
         this.count = coupons.size();
         this.coupons = coupons;
     }

--- a/src/main/java/com/unear/userservice/coupon/dto/response/UserCouponResponseDto.java
+++ b/src/main/java/com/unear/userservice/coupon/dto/response/UserCouponResponseDto.java
@@ -4,7 +4,7 @@ import com.unear.userservice.coupon.entity.UserCoupon;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Getter
 @Builder
@@ -13,8 +13,8 @@ public class UserCouponResponseDto {
     private String couponName;
     private String barcodeNumber;
     private String couponStatusCode;
-    private LocalDate createdAt;
-    private LocalDate couponEnd;
+    private LocalDateTime createdAt;
+    private LocalDateTime couponEnd;
 
     public static UserCouponResponseDto from(UserCoupon userCoupon) {
         return UserCouponResponseDto.builder()

--- a/src/main/java/com/unear/userservice/coupon/entity/CouponTemplate.java
+++ b/src/main/java/com/unear/userservice/coupon/entity/CouponTemplate.java
@@ -5,7 +5,7 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -26,8 +26,8 @@ public class CouponTemplate {
 
     private Integer remainingQuantity;
 
-    private LocalDate couponStart;
-    private LocalDate couponEnd;
+    private LocalDateTime couponStart;
+    private LocalDateTime couponEnd;
 
     private String discountCode;
     private String membershipCode;

--- a/src/main/java/com/unear/userservice/coupon/entity/UserCoupon.java
+++ b/src/main/java/com/unear/userservice/coupon/entity/UserCoupon.java
@@ -4,7 +4,7 @@ import com.unear.userservice.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "user_coupons")
@@ -27,8 +27,8 @@ public class UserCoupon {
     @JoinColumn(name = "coupon_template_id", nullable = false)
     private CouponTemplate couponTemplate;
 
-    private LocalDate createdAt;
-    private LocalDate usedAt;
+    private LocalDateTime createdAt;
+    private LocalDateTime usedAt;
 
     private String couponStatusCode;
     private String barcodeNumber;

--- a/src/main/java/com/unear/userservice/coupon/service/CouponService.java
+++ b/src/main/java/com/unear/userservice/coupon/service/CouponService.java
@@ -1,6 +1,7 @@
 package com.unear.userservice.coupon.service;
 
 import com.unear.userservice.coupon.dto.response.CouponResponseDto;
+import com.unear.userservice.coupon.dto.response.UserCouponDetailResponseDto;
 import com.unear.userservice.coupon.dto.response.UserCouponListResponseDto;
 import com.unear.userservice.coupon.dto.response.UserCouponResponseDto;
 
@@ -16,6 +17,6 @@ public interface CouponService {
 
     UserCouponListResponseDto getMyCoupons(Long userId);
 
-    UserCouponResponseDto getMyCouponDetail(Long userId, Long userCouponId);
+    UserCouponDetailResponseDto getMyCouponDetail(Long userId, Long userCouponId);
 
 }

--- a/src/main/java/com/unear/userservice/coupon/service/CouponService.java
+++ b/src/main/java/com/unear/userservice/coupon/service/CouponService.java
@@ -1,8 +1,8 @@
 package com.unear.userservice.coupon.service;
 
 import com.unear.userservice.coupon.dto.response.CouponResponseDto;
+import com.unear.userservice.coupon.dto.response.UserCouponListResponseDto;
 import com.unear.userservice.coupon.dto.response.UserCouponResponseDto;
-import com.unear.userservice.coupon.dto.response.UserCouponResponseListDto;
 
 import java.util.List;
 
@@ -14,7 +14,7 @@ public interface CouponService {
 
     UserCouponResponseDto downloadFCFSCoupon(Long userId, Long couponTemplateId);
 
-    UserCouponResponseListDto getMyCoupons(Long userId);
+    UserCouponListResponseDto getMyCoupons(Long userId);
 
     UserCouponResponseDto getMyCouponDetail(Long userId, Long userCouponId);
 

--- a/src/main/java/com/unear/userservice/coupon/service/impl/CouponServiceImpl.java
+++ b/src/main/java/com/unear/userservice/coupon/service/impl/CouponServiceImpl.java
@@ -24,6 +24,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -84,15 +85,15 @@ public class CouponServiceImpl implements CouponService {
         CouponTemplate template = couponTemplateRepository.findById(couponTemplateId)
                 .orElseThrow(() -> new CouponTemplateNotFoundException("쿠폰 템플릿을 찾을 수 없습니다."));
 
-        LocalDate today = LocalDate.now();
-        if (template.getCouponStart().isAfter(today) || template.getCouponEnd().isBefore(today)) {
+        LocalDateTime now = LocalDateTime.now();
+        if (template.getCouponStart().isAfter(now) || template.getCouponEnd().isBefore(now)) {
             throw new CouponExpiredException("유효 기간이 지난 쿠폰입니다.");
         }
 
         UserCoupon userCoupon = UserCoupon.builder()
                 .user(user)
                 .couponTemplate(template)
-                .createdAt(LocalDate.now())
+                .createdAt(LocalDateTime.now())
                 .couponStatusCode(CouponStatus.UNUSED.getCode())
                 .barcodeNumber(generateUniqueBarcode())
                 .build();
@@ -115,8 +116,8 @@ public class CouponServiceImpl implements CouponService {
         CouponTemplate template = couponTemplateRepository.findById(couponTemplateId)
                 .orElseThrow(() -> new CouponTemplateNotFoundException("쿠폰 템플릿을 찾을 수 없습니다."));
 
-        LocalDate today = LocalDate.now();
-        if (template.getCouponStart().isAfter(today) || template.getCouponEnd().isBefore(today)) {
+        LocalDateTime now = LocalDateTime.now();
+        if (template.getCouponStart().isAfter(now) || template.getCouponEnd().isBefore(now)) {
             throw new CouponExpiredException("유효 기간이 지난 쿠폰입니다.");
         }
 
@@ -125,7 +126,7 @@ public class CouponServiceImpl implements CouponService {
         UserCoupon userCoupon = UserCoupon.builder()
                 .user(user)
                 .couponTemplate(template)
-                .createdAt(LocalDate.now())
+                .createdAt(LocalDateTime.now())
                 .couponStatusCode(CouponStatus.UNUSED.getCode())
                 .barcodeNumber(generateUniqueBarcode())
                 .build();

--- a/src/main/java/com/unear/userservice/coupon/service/impl/CouponServiceImpl.java
+++ b/src/main/java/com/unear/userservice/coupon/service/impl/CouponServiceImpl.java
@@ -186,7 +186,7 @@ public class CouponServiceImpl implements CouponService {
                             .minPurchaseAmount(policy.getMinPurchaseAmount())
                             .maxDiscountAmount(policy.getMaxDiscountAmount())
             );
-        } else if (placeType.isBasic()){
+        } else if (placeType.isBasic()) {
             generalDiscountPolicyRepository.findById(template.getDiscountPolicyDetailId()).ifPresent(policy ->
                     builder
                             .discountCode(policy.getDiscountCode())

--- a/src/main/java/com/unear/userservice/coupon/service/impl/CouponServiceImpl.java
+++ b/src/main/java/com/unear/userservice/coupon/service/impl/CouponServiceImpl.java
@@ -6,8 +6,8 @@ import com.unear.userservice.common.enums.CouponStatus;
 import com.unear.userservice.common.enums.DiscountPolicy;
 import com.unear.userservice.common.enums.PlaceType;
 import com.unear.userservice.coupon.dto.response.CouponResponseDto;
+import com.unear.userservice.coupon.dto.response.UserCouponListResponseDto;
 import com.unear.userservice.coupon.dto.response.UserCouponResponseDto;
-import com.unear.userservice.coupon.dto.response.UserCouponResponseListDto;
 import com.unear.userservice.coupon.entity.CouponTemplate;
 import com.unear.userservice.coupon.entity.UserCoupon;
 import com.unear.userservice.coupon.repository.CouponTemplateRepository;
@@ -139,7 +139,7 @@ public class CouponServiceImpl implements CouponService {
 
 
     @Override
-    public UserCouponResponseListDto getMyCoupons(Long userId) {
+    public UserCouponListResponseDto getMyCoupons(Long userId) {
         userRepository.findById(userId)
                 .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
 
@@ -149,7 +149,7 @@ public class CouponServiceImpl implements CouponService {
                 .map(UserCouponResponseDto::from)
                 .toList();
 
-        return new UserCouponResponseListDto(dtoList);
+        return new UserCouponListResponseDto(dtoList);
     }
 
 

--- a/src/main/java/com/unear/userservice/coupon/service/impl/CouponServiceImpl.java
+++ b/src/main/java/com/unear/userservice/coupon/service/impl/CouponServiceImpl.java
@@ -159,7 +159,7 @@ public class CouponServiceImpl implements CouponService {
     @Override
     public UserCouponDetailResponseDto getMyCouponDetail(Long userId, Long userCouponId) {
         UserCoupon userCoupon = userCouponRepository.findByUserCouponIdAndUser_UserId(userCouponId, userId)
-                .orElseThrow(() -> new CouponTemplateNotFoundException("쿠폰을 찾을 수 없습니다."));
+                .orElseThrow(() -> new UserCouponNotFoundException("다운받은 쿠폰을 찾을 수 없습니다."));
         CouponTemplate template = userCoupon.getCouponTemplate();
         String markerCode = template.getMarkerCode();
 

--- a/src/main/java/com/unear/userservice/exception/ErrorCode.java
+++ b/src/main/java/com/unear/userservice/exception/ErrorCode.java
@@ -26,7 +26,8 @@ public enum ErrorCode {
     DUPLICATED_BARCODE(HttpStatus.BAD_REQUEST, "DUPLICATED_BARCODE" , "중복된 바코드 번호입니다."),
     COUPON_SOLD_OUT(HttpStatus.BAD_REQUEST, "COUPON_SOLD_OUT" , "쿠폰 재고가 없습니다."),
     COUPON_EXPIRED(HttpStatus.BAD_REQUEST, "COUPON_EXPIRED", "유효 기간이 지난 쿠폰입니다."),
-    UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED_USER", "인증되지 않은 사용자입니다.")
+    UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED_USER", "인증되지 않은 사용자입니다."),
+    USER_COUPON_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_COUPON_NOT_FOUND", "다운받은 쿠폰을 찾을 수 없습니다.")
     ;
 
 

--- a/src/main/java/com/unear/userservice/exception/exception/UserCouponNotFoundException.java
+++ b/src/main/java/com/unear/userservice/exception/exception/UserCouponNotFoundException.java
@@ -1,0 +1,14 @@
+package com.unear.userservice.exception.exception;
+
+import com.unear.userservice.exception.BusinessException;
+import com.unear.userservice.exception.ErrorCode;
+
+public class UserCouponNotFoundException extends BusinessException {
+    public UserCouponNotFoundException() {
+        super(ErrorCode.USER_COUPON_NOT_FOUND);
+    }
+
+    public UserCouponNotFoundException(String message) {
+        super(ErrorCode.USER_COUPON_NOT_FOUND, message);
+    }
+}


### PR DESCRIPTION
## PR 목적

- 기존 다운받은 쿠폰 조회 응답 필드 추가
- 퍼센트 할인 쿠폰 / 금액 할인 쿠폰 / 선착순 쿠폰 타입에 따라 결과 다르게 반환


## 변경 사항

- [#72 ]

## 주요 구현 내용

- GET /coupons/me/{userCouponId} api 응답 수정
- UserCouponDetailResponseDto 추가
- 다운받은 쿠폰 상세 조회시, placeType별 할인정책 다르게 조회
- GeneralDiscountPolicy 필드명 수정 


## 테스트 및 동작 화면 (필요 시 첨부)

- 퍼센트 할인 쿠폰 조회
<img width="347" height="400" alt="스크린샷 2025-07-21 오후 4 47 27" src="https://github.com/user-attachments/assets/94189181-ba6a-463e-8034-9c774c903c32" />

- 금액 할인 쿠폰 조회
<img width="348" height="386" alt="스크린샷 2025-07-21 오후 4 49 34" src="https://github.com/user-attachments/assets/88c493d3-4a6f-4761-afe0-02a271de9992" />

- 선착순 쿠폰 조회
<img width="363" height="390" alt="스크린샷 2025-07-21 오후 4 49 50" src="https://github.com/user-attachments/assets/126b5de2-c839-44a1-8d7e-9dbd30352c96" />



## 리뷰 시 중점적으로 봐야 할 부분

## 병합 전 체크리스트

- [v] 로컬 테스트 완료
- [v] Postman 테스트 포함
- [v] 코드래빗 리뷰 검토
