### PR TITLE
[Wl7-326] 쿠폰 템플릿 조회

### DIFF
--- a/src/main/java/com/unear/userservice/common/docs/coupon/CouponApiDocs.java
+++ b/src/main/java/com/unear/userservice/common/docs/coupon/CouponApiDocs.java
@@ -27,7 +27,7 @@ public class CouponApiDocs {
                     examples = {
                             @ExampleObject(
                                     name = "BasicCoupon",
-                                    summary = "기본혜택 장소 쿠폰템플릿 조회 (markerCode == BASIC ) ",
+                                    summary = "기본혜택 장소 쿠폰템플릿 조회 (place_id = 149 , markerCode = BASIC ) ",
                                     value = """
                                     {
                                         "resultCode": 200,
@@ -50,7 +50,7 @@ public class CouponApiDocs {
                             ),
                             @ExampleObject(
                                     name = "FranchiseCoupon",
-                                    summary = "프랜차이즈 장소 쿠폰템플릿 조회 (markerCode == FRANCHISE )",
+                                    summary = "프랜차이즈 장소 쿠폰템플릿 조회 ( place_id = 130 ,markerCode == FRANCHISE )",
                                     value = """
                                     {
                                         "resultCode": 200,

--- a/src/main/java/com/unear/userservice/common/docs/coupon/CouponApiDocs.java
+++ b/src/main/java/com/unear/userservice/common/docs/coupon/CouponApiDocs.java
@@ -16,7 +16,8 @@ public class CouponApiDocs {
     @Documented
     @Operation(
             summary = "장소 + 마커 코드로 쿠폰 템플릿 조회",
-            description = "특정 장소 ID와 마커 코드(markerCode)에 해당하는 사용자의 쿠폰 템플릿 리스트를 조회합니다. markerCode 종류는 BASIC 과 FRANCHISE 입니다."
+            description = "특정 장소 ID와 마커 코드(markerCode)에 해당하는 사용자의 쿠폰 템플릿을 조회합니다. markerCode 종류는 BASIC 과 FRANCHISE 입니다. 이미 다운받은 쿠폰은 downloaded 가 true 입니다. \n"
+            + "현재 사용자의 멤버등급을 기준으로 해당되는 쿠폰템플릿만 조회됩니다."
     )
     @ApiResponse(
             responseCode = "200",
@@ -57,33 +58,13 @@ public class CouponApiDocs {
                                         "message": "쿠폰 템플릿 조회 성공",
                                         "data": [
                                             {
-                                                "couponTemplateId": 4,
-                                                "couponName": "GS THE FRESH",
-                                                "discountCode": "COUPON_FIXED",
-                                                "membershipCode": "VVIP",
-                                                "discountInfo": "(쿠폰) 금액 할인",
-                                                "couponStart": "2025-07-01",
-                                                "couponEnd": "2025-07-30",
-                                                "downloaded": false
-                                            },
-                                            {
                                                 "couponTemplateId": 5,
                                                 "couponName": "GS THE FRESH",
                                                 "discountCode": "COUPON_FIXED",
                                                 "membershipCode": "VIP",
                                                 "discountInfo": "(쿠폰) 금액 할인",
-                                                "couponStart": "2025-07-01",
-                                                "couponEnd": "2025-07-30",
-                                                "downloaded": false
-                                            },
-                                            {
-                                                "couponTemplateId": 6,
-                                                "couponName": "GS THE FRESH",
-                                                "discountCode": "COUPON_FIXED",
-                                                "membershipCode": "BASIC",
-                                                "discountInfo": "(쿠폰) 금액 할인",
-                                                "couponStart": "2025-07-01",
-                                                "couponEnd": "2025-07-30",
+                                                "couponStart": "2025-07-01T00:00:00",
+                                                "couponEnd": "2025-07-30T00:00:00",
                                                 "downloaded": false
                                             }
                                         ]

--- a/src/main/java/com/unear/userservice/common/enums/MembershipGrade.java
+++ b/src/main/java/com/unear/userservice/common/enums/MembershipGrade.java
@@ -27,4 +27,9 @@ public enum MembershipGrade {
                 .findFirst()
                 .orElseThrow(() -> new InvalidCodeException("Invalid membership code: " + code));
     }
+
+    public static boolean isAll(String code) {
+        return ALL.name().equalsIgnoreCase(code);
+    }
+
 }

--- a/src/main/java/com/unear/userservice/common/enums/MembershipGrade.java
+++ b/src/main/java/com/unear/userservice/common/enums/MembershipGrade.java
@@ -29,7 +29,7 @@ public enum MembershipGrade {
     }
 
     public static boolean isAll(String code) {
-        return ALL.name().equalsIgnoreCase(code);
+        return ALL.code.equalsIgnoreCase(code);
     }
 
 }

--- a/src/main/java/com/unear/userservice/coupon/service/impl/CouponServiceImpl.java
+++ b/src/main/java/com/unear/userservice/coupon/service/impl/CouponServiceImpl.java
@@ -65,7 +65,25 @@ public class CouponServiceImpl implements CouponService {
                 ? userCouponRepository.findCouponTemplateIdsByUserId(userId)
                 : Set.of();
 
+        final String userMembershipCode =
+                (userId != null && placeType.isFranchise())
+                        ? userRepository.findMembershipCodeByUserId(userId)
+                        : null;
+
         return templates.stream()
+                .filter(template -> {
+
+                    if (!placeType.isFranchise()) return true;
+
+                    String templateMembershipCode = template.getMembershipCode();
+                    if (templateMembershipCode == null) return false;
+
+                    if ("ALL".equalsIgnoreCase(templateMembershipCode)) return true;
+
+                    if (userMembershipCode == null) return false;
+
+                    return templateMembershipCode.equalsIgnoreCase(userMembershipCode);
+                })
                 .map(template -> {
                     String discountInfo = DiscountPolicy.fromCode(template.getDiscountCode()).getLabel();
                     boolean isDownloaded = downloadedIds.contains(template.getCouponTemplateId());

--- a/src/main/java/com/unear/userservice/coupon/service/impl/CouponServiceImpl.java
+++ b/src/main/java/com/unear/userservice/coupon/service/impl/CouponServiceImpl.java
@@ -4,6 +4,7 @@ import com.unear.userservice.benefit.repository.FranchiseDiscountPolicyRepositor
 import com.unear.userservice.benefit.repository.GeneralDiscountPolicyRepository;
 import com.unear.userservice.common.enums.CouponStatus;
 import com.unear.userservice.common.enums.DiscountPolicy;
+import com.unear.userservice.common.enums.MembershipGrade;
 import com.unear.userservice.common.enums.PlaceType;
 import com.unear.userservice.common.exception.exception.*;
 import com.unear.userservice.coupon.dto.response.CouponResponseDto;
@@ -78,7 +79,7 @@ public class CouponServiceImpl implements CouponService {
                     String templateMembershipCode = template.getMembershipCode();
                     if (templateMembershipCode == null) return false;
 
-                    if ("ALL".equalsIgnoreCase(templateMembershipCode)) return true;
+                    if (MembershipGrade.isAll(templateMembershipCode)) return true;
 
                     if (userMembershipCode == null) return false;
 

--- a/src/main/java/com/unear/userservice/user/repository/UserRepository.java
+++ b/src/main/java/com/unear/userservice/user/repository/UserRepository.java
@@ -2,6 +2,8 @@ package com.unear.userservice.user.repository;
 
 import com.unear.userservice.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -17,4 +19,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
 
     Optional<User> findByBarcodeNumber(String barcodeNumber);
+
+    @Query("SELECT u.membershipCode FROM User u WHERE u.userId = :userId")
+    String findMembershipCodeByUserId(@Param("userId") Long userId);
+
 }


### PR DESCRIPTION
## PR 목적

- 기존 placeId + markerCode 쿠폰 템플릿 조회 로직 -> 사용자의 멤버십등급 기반으로 다운받을수 있는 쿠폰만 조회되도록 수정

## 주요 구현 내용

- CouponServiceImpl -> 쿠폰 템플릿 조회 로직에 멤버십 등급 필터링 추가
- MembershipGrade -> isAll 메서드 추가


## 테스트 및 동작 화면 (필요 시 첨부)

- 프랜차이즈 장소 쿠폰 템플릿 조회 ( 현재 사용자 등급은 VIP )
<img width="369" height="315" alt="스크린샷 2025-07-22 오후 7 55 33" src="https://github.com/user-attachments/assets/7e5c0687-58b5-4c8c-9449-7ebc54be7d0f" />

## 병합 전 체크리스트

- [v] 로컬 테스트 완료
- [v] Postman 테스트 포함
- [v] Swagger 동작 확인
- [v] 코드래빗 리뷰 검토
