### PR TITLE
[WL7-323] OAuth , 이메일 회원가입시 isProfileComplete로 분기

### DIFF
--- a/src/main/java/com/unear/userservice/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/unear/userservice/auth/service/impl/AuthServiceImpl.java
@@ -119,8 +119,8 @@ public class AuthServiceImpl implements AuthService {
                 .tel(dto.getTel())
                 .birthdate(dto.getBirthdate())
                 .gender(dto.getGender())
-                .membershipCode("001")
-                .isProfileComplete(false)
+                .membershipCode("BASIC")
+                .isProfileComplete(true)
                 .barcodeNumber(barcode)
                 .build();
 

--- a/src/main/java/com/unear/userservice/auth/service/impl/GoogleOAuth2UserService.java
+++ b/src/main/java/com/unear/userservice/auth/service/impl/GoogleOAuth2UserService.java
@@ -30,8 +30,6 @@ public class GoogleOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         String email = (String) attributes.get("email");
         String name = (String) attributes.get("name");
 
-        String barcode = UUID.randomUUID().toString().replace("-", "").substring(0, 16);
-
         User user = userRepository.findByEmail(email)
                 .orElseGet(() -> userRepository.save(
                         User.builder()
@@ -41,9 +39,9 @@ public class GoogleOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
                                 .tel(null)
                                 .birthdate(null)
                                 .gender(null)
-                                .membershipCode("001")
-                                .isProfileComplete(true)
-                                .barcodeNumber(barcode)
+                                .membershipCode("BASIC")
+                                .isProfileComplete(false)
+                                .barcodeNumber(null)
                                 .build()
                 ));
 

--- a/src/main/java/com/unear/userservice/auth/service/impl/KakaoOAuth2UserService.java
+++ b/src/main/java/com/unear/userservice/auth/service/impl/KakaoOAuth2UserService.java
@@ -42,7 +42,6 @@ public class KakaoOAuth2UserService extends DefaultOAuth2UserService {
         if (email == null) {
             throw new OAuth2AuthenticationException("카카오 계정에서 이메일 정보를 가져올 수 없습니다. 이메일 제공에 동의했는지 확인해주세요.");
         }
-        String barcode = UUID.randomUUID().toString().replace("-", "").substring(0, 16);
 
         User savedUser = userRepository.findByEmail(email)
                 .orElseGet(() -> userRepository.save(
@@ -53,9 +52,9 @@ public class KakaoOAuth2UserService extends DefaultOAuth2UserService {
                                 .tel(null)
                                 .birthdate(null)
                                 .gender(null)
-                                .membershipCode("001")
-                                .isProfileComplete(true)
-                                .barcodeNumber(barcode)
+                                .membershipCode("BASIC")
+                                .isProfileComplete(false)
+                                .barcodeNumber(null)
                                 .build()
                 ));
 


### PR DESCRIPTION
## PR 목적

- OAuth 회원가입시 isProfileComplete = false
- 이메일 회원가입시 isProfileComplete = true로 분기 처리



## 변경 사항

- OAuth -> loadUser 사용자 저장값에서 barcode 제거
- 이름과 이메일을 제외한 모든 정보 AuthServiceImpl의 signup에서 수행


## 병합 전 체크리스트

- [v] 로컬 테스트 완료
- [v] Postman 테스트 포함
- [v] 코드래빗 리뷰 검토
