### PR TITLE
[WL7-69] 이벤트 정보 조회 ( Add event detail retrieval and expand event and coupon entity structures )

### DIFF
--- a/src/main/java/com/unear/userservice/common/enums/EventType.java
+++ b/src/main/java/com/unear/userservice/common/enums/EventType.java
@@ -1,0 +1,14 @@
+package com.unear.userservice.common.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum EventType {
+    NONE("이벤트 아님"),
+    GENERAL("이벤트(일반)"),
+    REQUIRE("이벤트(필수)");
+
+    private final String label;
+}

--- a/src/main/java/com/unear/userservice/common/exception/ErrorCode.java
+++ b/src/main/java/com/unear/userservice/common/exception/ErrorCode.java
@@ -1,6 +1,7 @@
 package com.unear.userservice.common.exception;
 
 
+import com.unear.userservice.common.enums.EventType;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
@@ -27,7 +28,8 @@ public enum ErrorCode {
     COUPON_SOLD_OUT(HttpStatus.BAD_REQUEST, "COUPON_SOLD_OUT" , "쿠폰 재고가 없습니다."),
     COUPON_EXPIRED(HttpStatus.BAD_REQUEST, "COUPON_EXPIRED", "유효 기간이 지난 쿠폰입니다."),
     UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED_USER", "인증되지 않은 사용자입니다."),
-    USER_COUPON_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_COUPON_NOT_FOUND", "다운받은 쿠폰을 찾을 수 없습니다.")
+    USER_COUPON_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_COUPON_NOT_FOUND", "다운받은 쿠폰을 찾을 수 없습니다."),
+    EVENT_NOT_FOUND(HttpStatus.NOT_FOUND,"EVENT_NOT_FOUND","이벤트를 찾지 못했습니다.")
     ;
 
 

--- a/src/main/java/com/unear/userservice/coupon/dto/response/CouponResponseDto.java
+++ b/src/main/java/com/unear/userservice/coupon/dto/response/CouponResponseDto.java
@@ -24,7 +24,7 @@ public class CouponResponseDto {
         return CouponResponseDto.builder()
                 .couponTemplateId(entity.getCouponTemplateId())
                 .couponName(entity.getCouponName())
-                .discountCode(entity.getDiscountCode())
+                .discountCode(entity.getDiscountCode().getCode())
                 .membershipCode(entity.getMembershipCode())
                 .discountInfo(discountInfo)
                 .couponStart(entity.getCouponStart())

--- a/src/main/java/com/unear/userservice/coupon/entity/CouponTemplate.java
+++ b/src/main/java/com/unear/userservice/coupon/entity/CouponTemplate.java
@@ -1,6 +1,8 @@
 package com.unear.userservice.coupon.entity;
 
+import com.unear.userservice.common.enums.DiscountPolicy;
 import com.unear.userservice.common.exception.exception.CouponSoldOutException;
+import com.unear.userservice.event.entity.UnearEvent;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
@@ -29,11 +31,18 @@ public class CouponTemplate {
     private LocalDateTime couponStart;
     private LocalDateTime couponEnd;
 
-    private String discountCode;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "discount_code")
+    private DiscountPolicy discountCode;
+
     private String membershipCode;
 
     @OneToMany(mappedBy = "couponTemplate")
     private List<UserCoupon> userCoupons = new ArrayList<>();
+
+    @ManyToOne
+    @JoinColumn(name = "unear_event_id")
+    private UnearEvent event;
 
     public void decreaseQuantity() {
         if (this.remainingQuantity <= 0) {

--- a/src/main/java/com/unear/userservice/coupon/repository/CouponTemplateRepository.java
+++ b/src/main/java/com/unear/userservice/coupon/repository/CouponTemplateRepository.java
@@ -1,10 +1,24 @@
 package com.unear.userservice.coupon.repository;
 
+import com.unear.userservice.common.enums.DiscountPolicy;
 import com.unear.userservice.coupon.entity.CouponTemplate;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface CouponTemplateRepository extends JpaRepository<CouponTemplate, Long> {
     List<CouponTemplate> findByDiscountPolicyDetailIdInAndMarkerCode(List<Long> discountPolicyIds, String markerCode);
+
+    @Query("""
+SELECT ct
+FROM CouponTemplate ct
+WHERE ct.event.unearEventId = :eventId
+AND ct.discountCode = :discountCode
+""")
+    List<CouponTemplate> findByEventIdAndDiscountCode(
+            @Param("eventId") Long eventId,
+            @Param("discountCode") DiscountPolicy discountCode
+    );
 }

--- a/src/main/java/com/unear/userservice/coupon/service/impl/CouponServiceImpl.java
+++ b/src/main/java/com/unear/userservice/coupon/service/impl/CouponServiceImpl.java
@@ -86,7 +86,7 @@ public class CouponServiceImpl implements CouponService {
                     return templateMembershipCode.equalsIgnoreCase(userMembershipCode);
                 })
                 .map(template -> {
-                    String discountInfo = DiscountPolicy.fromCode(template.getDiscountCode()).getLabel();
+                    String discountInfo = DiscountPolicy.fromCode(template.getDiscountCode().getCode()).getLabel();
                     boolean isDownloaded = downloadedIds.contains(template.getCouponTemplateId());
                     return CouponResponseDto.from(template, discountInfo, isDownloaded);
                 })

--- a/src/main/java/com/unear/userservice/event/controller/EventController.java
+++ b/src/main/java/com/unear/userservice/event/controller/EventController.java
@@ -1,0 +1,22 @@
+package com.unear.userservice.event.controller;
+
+import com.unear.userservice.common.response.ApiResponse;
+import com.unear.userservice.event.dto.response.EventDetailResponseDto;
+import com.unear.userservice.event.service.EventService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/events")
+@RequiredArgsConstructor
+public class EventController {
+
+    private final EventService eventService;
+
+    @GetMapping("/{eventId}")
+    public ResponseEntity<ApiResponse<EventDetailResponseDto>> getEventDetail(@PathVariable Long eventId) {
+        EventDetailResponseDto dto = eventService.findEventDetailById(eventId);
+        return ResponseEntity.ok(ApiResponse.success(dto));
+    }
+}

--- a/src/main/java/com/unear/userservice/event/dto/response/EventCouponResponseDto.java
+++ b/src/main/java/com/unear/userservice/event/dto/response/EventCouponResponseDto.java
@@ -1,0 +1,21 @@
+package com.unear.userservice.event.dto.response;
+
+import com.unear.userservice.coupon.entity.CouponTemplate;
+
+import java.time.LocalDate;
+
+public record EventCouponResponseDto(
+        Long couponId,
+        String couponName,
+        LocalDate startDate,
+        LocalDate endDate
+) {
+    public static EventCouponResponseDto from(CouponTemplate coupon) {
+        return new EventCouponResponseDto(
+                coupon.getCouponTemplateId(),
+                coupon.getCouponName(),
+                coupon.getCouponStart().toLocalDate(),
+                coupon.getCouponEnd().toLocalDate()
+        );
+    }
+}

--- a/src/main/java/com/unear/userservice/event/dto/response/EventDetailResponseDto.java
+++ b/src/main/java/com/unear/userservice/event/dto/response/EventDetailResponseDto.java
@@ -1,0 +1,46 @@
+package com.unear.userservice.event.dto.response;
+
+
+import com.unear.userservice.event.entity.UnearEvent;
+import com.unear.userservice.place.entity.Place;
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+@Builder
+public record EventDetailResponseDto(
+        Long eventId,
+        String eventName,
+        String description,
+        BigDecimal latitude,
+        BigDecimal longitude,
+        Integer radius,
+        LocalDate startDate,
+        LocalDate endDate,
+        EventPlaceResponseDto popupStore,
+        List<EventPlaceResponseDto> partnerStores,
+        List<EventCouponResponseDto> coupons
+) {
+    public static EventDetailResponseDto of(
+            UnearEvent event,
+            Place popupStore,
+            List<Place> partnerPlaces,
+            List<EventCouponResponseDto> coupons
+    ) {
+        return EventDetailResponseDto.builder()
+                .eventId(event.getUnearEventId())
+                .eventName(event.getEventName())
+                .description(event.getEventDescription())
+                .latitude(event.getLatitude())
+                .longitude(event.getLongitude())
+                .radius(event.getRadiusMeter())
+                .startDate(event.getStartAt())
+                .endDate(event.getEndAt())
+                .popupStore(popupStore != null ? EventPlaceResponseDto.from(popupStore) : null)
+                .partnerStores(partnerPlaces.stream().map(EventPlaceResponseDto::from).toList())
+                .coupons(coupons)
+                .build();
+    }
+}

--- a/src/main/java/com/unear/userservice/event/dto/response/EventPlaceResponseDto.java
+++ b/src/main/java/com/unear/userservice/event/dto/response/EventPlaceResponseDto.java
@@ -1,0 +1,17 @@
+package com.unear.userservice.event.dto.response;
+
+import com.unear.userservice.place.entity.Place;
+
+public record EventPlaceResponseDto(
+        Long placeId,
+        String placeName,
+        String address
+) {
+    public static EventPlaceResponseDto from(Place place) {
+        return new EventPlaceResponseDto(
+                place.getPlaceId(),
+                place.getPlaceName(),
+                place.getAddress()
+        );
+    }
+}

--- a/src/main/java/com/unear/userservice/event/entity/UnearEvent.java
+++ b/src/main/java/com/unear/userservice/event/entity/UnearEvent.java
@@ -1,6 +1,7 @@
 package com.unear.userservice.event.entity;
 
 import com.unear.userservice.benefit.entity.RouletteResult;
+import com.unear.userservice.coupon.entity.CouponTemplate;
 import com.unear.userservice.place.entity.EventPlace;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -29,7 +30,7 @@ public class UnearEvent {
     @Column(precision = 10, scale = 7)
     private BigDecimal longitude;
 
-    private BigDecimal radiusMeter;
+    private Integer radiusMeter;
     private LocalDate startAt;
     private LocalDate endAt;
 
@@ -38,6 +39,9 @@ public class UnearEvent {
 
     @OneToMany(mappedBy = "event")
     private List<RouletteResult> rouletteResults = new ArrayList<>();
+
+    @OneToMany(mappedBy = "event", fetch = FetchType.LAZY)
+    private List<CouponTemplate> couponTemplates = new ArrayList<>();
 
 }
 

--- a/src/main/java/com/unear/userservice/event/repository/EventRepository.java
+++ b/src/main/java/com/unear/userservice/event/repository/EventRepository.java
@@ -1,0 +1,33 @@
+package com.unear.userservice.event.repository;
+
+import com.unear.userservice.coupon.entity.CouponTemplate;
+import com.unear.userservice.event.entity.UnearEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface EventRepository extends JpaRepository<UnearEvent, Long> {
+
+    @Query("""
+SELECT DISTINCT e
+FROM UnearEvent e
+LEFT JOIN FETCH e.eventPlaces ep
+LEFT JOIN FETCH ep.place p
+WHERE e.unearEventId = :eventId
+""")
+    Optional<UnearEvent> findEventWithPlaces(@Param("eventId") Long eventId);
+
+
+
+    @Query("""
+SELECT c
+FROM CouponTemplate c
+WHERE c.event.unearEventId = :eventId
+  AND c.discountCode = 'COUPON_FCFS'
+""")
+    List<CouponTemplate> findFcfsCouponsByEventId(@Param("eventId") Long eventId);
+
+}

--- a/src/main/java/com/unear/userservice/event/repository/EventRepository.java
+++ b/src/main/java/com/unear/userservice/event/repository/EventRepository.java
@@ -26,8 +26,14 @@ WHERE e.unearEventId = :eventId
 SELECT c
 FROM CouponTemplate c
 WHERE c.event.unearEventId = :eventId
-  AND c.discountCode = 'COUPON_FCFS'
+  AND c.discountCode = :discountCode
 """)
-    List<CouponTemplate> findFcfsCouponsByEventId(@Param("eventId") Long eventId);
+    List<CouponTemplate> findByEventIdAndDiscountCode(
+        @Param("eventId") Long eventId,
+        @Param("discountCode") String discountCode
+    );
+
+    // Or, if you prefer to move filtering logic into the service layer:
+    List<CouponTemplate> findByEventUnearEventId(Long eventId);
 
 }

--- a/src/main/java/com/unear/userservice/event/service/EventService.java
+++ b/src/main/java/com/unear/userservice/event/service/EventService.java
@@ -1,0 +1,7 @@
+package com.unear.userservice.event.service;
+
+import com.unear.userservice.event.dto.response.EventDetailResponseDto;
+
+public interface EventService {
+    EventDetailResponseDto findEventDetailById(Long eventId);
+}

--- a/src/main/java/com/unear/userservice/event/service/impl/EventServiceImpl.java
+++ b/src/main/java/com/unear/userservice/event/service/impl/EventServiceImpl.java
@@ -36,7 +36,6 @@ public class EventServiceImpl implements EventService {
 
         List<EventPlace> eventPlaces = event.getEventPlaces();
 
-        // 📍 팝업스토어 (REQUIRE)
         Place popupStore = eventPlaces.stream()
                 .filter(ep -> EventType.REQUIRE.name().equalsIgnoreCase(ep.getEventCode()))
                 .map(EventPlace::getPlace)
@@ -44,7 +43,6 @@ public class EventServiceImpl implements EventService {
                 .findFirst()
                 .orElse(null);
 
-        // 📍 일반 제휴처 (GENERAL, 최대 3개)
         List<Place> generalPlaces = eventPlaces.stream()
                 .filter(ep -> EventType.GENERAL.name().equalsIgnoreCase(ep.getEventCode()))
                 .map(EventPlace::getPlace)
@@ -52,7 +50,6 @@ public class EventServiceImpl implements EventService {
                 .limit(3)
                 .toList();
 
-        // 📍 쿠폰 (COUPON_FCFS) - 팝업스토어 markerCode 기준으로 필터링
         List<CouponTemplate> fcfsCoupons = couponTemplateRepository
                 .findByEventIdAndDiscountCode(eventId, DiscountPolicy.COUPON_FCFS);
 

--- a/src/main/java/com/unear/userservice/event/service/impl/EventServiceImpl.java
+++ b/src/main/java/com/unear/userservice/event/service/impl/EventServiceImpl.java
@@ -32,7 +32,7 @@ public class EventServiceImpl implements EventService {
     @Override
     public EventDetailResponseDto findEventDetailById(Long eventId) {
         UnearEvent event = eventRepository.findEventWithPlaces(eventId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 이벤트가 존재하지 않습니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.EVENT_NOT_FOUND));
 
         List<EventPlace> eventPlaces = event.getEventPlaces();
 

--- a/src/main/java/com/unear/userservice/event/service/impl/EventServiceImpl.java
+++ b/src/main/java/com/unear/userservice/event/service/impl/EventServiceImpl.java
@@ -1,0 +1,66 @@
+package com.unear.userservice.event.service.impl;
+
+import com.unear.userservice.common.enums.DiscountPolicy;
+import com.unear.userservice.common.enums.EventType;
+import com.unear.userservice.common.exception.BusinessException;
+import com.unear.userservice.common.exception.ErrorCode;
+import com.unear.userservice.coupon.repository.CouponTemplateRepository;
+import com.unear.userservice.event.dto.response.EventCouponResponseDto;
+import com.unear.userservice.event.dto.response.EventDetailResponseDto;
+import com.unear.userservice.event.dto.response.EventPlaceResponseDto;
+import com.unear.userservice.event.entity.UnearEvent;
+import com.unear.userservice.event.repository.EventRepository;
+import com.unear.userservice.event.service.EventService;
+import com.unear.userservice.place.entity.Place;
+import com.unear.userservice.place.entity.EventPlace;
+import com.unear.userservice.coupon.entity.CouponTemplate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EventServiceImpl implements EventService {
+
+    private final EventRepository eventRepository;
+    private final CouponTemplateRepository couponTemplateRepository;
+
+    @Override
+    public EventDetailResponseDto findEventDetailById(Long eventId) {
+        UnearEvent event = eventRepository.findEventWithPlaces(eventId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 이벤트가 존재하지 않습니다."));
+
+        List<EventPlace> eventPlaces = event.getEventPlaces();
+
+        // 📍 팝업스토어 (REQUIRE)
+        Place popupStore = eventPlaces.stream()
+                .filter(ep -> EventType.REQUIRE.name().equalsIgnoreCase(ep.getEventCode()))
+                .map(EventPlace::getPlace)
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElse(null);
+
+        // 📍 일반 제휴처 (GENERAL, 최대 3개)
+        List<Place> generalPlaces = eventPlaces.stream()
+                .filter(ep -> EventType.GENERAL.name().equalsIgnoreCase(ep.getEventCode()))
+                .map(EventPlace::getPlace)
+                .filter(Objects::nonNull)
+                .limit(3)
+                .toList();
+
+        // 📍 쿠폰 (COUPON_FCFS) - 팝업스토어 markerCode 기준으로 필터링
+        List<CouponTemplate> fcfsCoupons = couponTemplateRepository
+                .findByEventIdAndDiscountCode(eventId, DiscountPolicy.COUPON_FCFS);
+
+        List<EventCouponResponseDto> couponDtos = fcfsCoupons.stream()
+                .filter(c -> popupStore != null && Objects.equals(c.getMarkerCode(), popupStore.getMarkerCode()))
+                .map(EventCouponResponseDto::from)
+                .toList();
+
+        return EventDetailResponseDto.of(event, popupStore, generalPlaces, couponDtos);
+    }
+}


### PR DESCRIPTION
## PR 목적

이번주니어 이벤트 지역 정보, 팝업스토어, 이벤트 제휴처3곳, 선착순 쿠폰 조회



## 변경 사항

#92 



## 주요 구현 내용

event패키지 내 컨트롤러, responseDto, repository, service 등 작성


## 테스트 및 동작 화면 (필요 시 첨부)

<img width="910" height="658" alt="image" src="https://github.com/user-attachments/assets/c2181964-1e22-4731-bbf5-76b3126e66e9" />




## 리뷰 시 중점적으로 봐야 할 부분



## 병합 전 체크리스트

- [x] 로컬 테스트 완료
- [x] Postman 테스트 포함
- [ ] Swagger 동작 확인
- [ ] 코드래빗 리뷰 검토
