### PR TITLE
[WL7-69] 이벤트 정보 조회 방식 변경 ( Refactor event detail retrieval and separate entities and repositories )

### DIFF
--- a/src/main/java/com/unear/userservice/coupon/repository/CouponTemplateRepository.java
+++ b/src/main/java/com/unear/userservice/coupon/repository/CouponTemplateRepository.java
@@ -19,7 +19,7 @@ FROM CouponTemplate ct
 WHERE ct.event.unearEventId = :eventId
 AND ct.discountCode = :discountCode
 """)
-List<CouponTemplate> findByEventIdAndDiscountCode(
+List<CouponTemplate> findByEventCoupon(
     @Param("eventId") Long eventId,
     @Param("discountCode") DiscountPolicy discountPolicy  
 );
@@ -49,4 +49,6 @@ List<CouponTemplate> findByPlacesAndMembership(
     @Param("franchises") List<Franchise> franchises,
     @Param("membershipCode") String membershipCode
 );
+
+
 }

--- a/src/main/java/com/unear/userservice/event/controller/EventController.java
+++ b/src/main/java/com/unear/userservice/event/controller/EventController.java
@@ -16,7 +16,7 @@ public class EventController {
 
     @GetMapping("/{eventId}")
     public ResponseEntity<ApiResponse<EventDetailResponseDto>> getEventDetail(@PathVariable Long eventId) {
-        EventDetailResponseDto dto = eventService.findEventDetailById(eventId);
+        EventDetailResponseDto dto = eventService.getEventDetail(eventId);
         return ResponseEntity.ok(ApiResponse.success(dto));
     }
 }

--- a/src/main/java/com/unear/userservice/event/entity/UnearEvent.java
+++ b/src/main/java/com/unear/userservice/event/entity/UnearEvent.java
@@ -17,7 +17,9 @@ import java.util.List;
 @Getter
 @Setter
 public class UnearEvent {
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "unear_event_id")
     private Long unearEventId;
 
     private Long couponTemplateId;

--- a/src/main/java/com/unear/userservice/event/repository/EventRepository.java
+++ b/src/main/java/com/unear/userservice/event/repository/EventRepository.java
@@ -1,7 +1,10 @@
 package com.unear.userservice.event.repository;
 
+import com.unear.userservice.common.enums.DiscountPolicy;
+import com.unear.userservice.common.enums.EventType;
 import com.unear.userservice.coupon.entity.CouponTemplate;
 import com.unear.userservice.event.entity.UnearEvent;
+import com.unear.userservice.place.entity.EventPlace;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -19,6 +22,9 @@ LEFT JOIN FETCH ep.place p
 WHERE e.unearEventId = :eventId
 """)
     Optional<UnearEvent> findEventWithPlaces(@Param("eventId") Long eventId);
+
+
+
 
 
 }

--- a/src/main/java/com/unear/userservice/event/service/EventService.java
+++ b/src/main/java/com/unear/userservice/event/service/EventService.java
@@ -3,5 +3,5 @@ package com.unear.userservice.event.service;
 import com.unear.userservice.event.dto.response.EventDetailResponseDto;
 
 public interface EventService {
-    EventDetailResponseDto findEventDetailById(Long eventId);
+    EventDetailResponseDto getEventDetail(Long eventId);
 }

--- a/src/main/java/com/unear/userservice/event/service/impl/EventServiceImpl.java
+++ b/src/main/java/com/unear/userservice/event/service/impl/EventServiceImpl.java
@@ -2,24 +2,21 @@ package com.unear.userservice.event.service.impl;
 
 import com.unear.userservice.common.enums.DiscountPolicy;
 import com.unear.userservice.common.enums.EventType;
-import com.unear.userservice.common.exception.BusinessException;
-import com.unear.userservice.common.exception.ErrorCode;
 import com.unear.userservice.coupon.repository.CouponTemplateRepository;
 import com.unear.userservice.event.dto.response.EventCouponResponseDto;
 import com.unear.userservice.event.dto.response.EventDetailResponseDto;
-import com.unear.userservice.event.dto.response.EventPlaceResponseDto;
 import com.unear.userservice.event.entity.UnearEvent;
 import com.unear.userservice.event.repository.EventRepository;
 import com.unear.userservice.event.service.EventService;
 import com.unear.userservice.place.entity.Place;
 import com.unear.userservice.place.entity.EventPlace;
 import com.unear.userservice.coupon.entity.CouponTemplate;
+import com.unear.userservice.place.repository.EventPlaceRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -27,37 +24,36 @@ import java.util.Objects;
 public class EventServiceImpl implements EventService {
 
     private final EventRepository eventRepository;
+    private final EventPlaceRepository eventPlaceRepository;
     private final CouponTemplateRepository couponTemplateRepository;
 
     @Override
-    public EventDetailResponseDto findEventDetailById(Long eventId) {
-        UnearEvent event = eventRepository.findEventWithPlaces(eventId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.EVENT_NOT_FOUND));
+    public EventDetailResponseDto getEventDetail(Long eventId) {
+        // 1. 이벤트 조회
+        UnearEvent event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new IllegalArgumentException("이벤트를 찾을 수 없습니다."));
 
-        List<EventPlace> eventPlaces = event.getEventPlaces();
-
-        Place popupStore = eventPlaces.stream()
-                .filter(ep -> EventType.REQUIRE.name().equalsIgnoreCase(ep.getEventCode()))
-                .map(EventPlace::getPlace)
-                .filter(Objects::nonNull)
+        // 2. 팝업스토어 조회
+        List<EventPlace> popupList = eventPlaceRepository.findByEventPopup(eventId, EventType.REQUIRE);
+        Place popupStore = popupList.stream()
                 .findFirst()
-                .orElse(null);
+                .orElseThrow(() -> new IllegalArgumentException("팝업스토어가 존재하지 않습니다."))
+                .getPlace();
 
-        List<Place> generalPlaces = eventPlaces.stream()
-                .filter(ep -> EventType.GENERAL.name().equalsIgnoreCase(ep.getEventCode()))
+        // 3. 제휴처(GENERAL) 조회
+        List<EventPlace> eventPlaces = eventPlaceRepository.findByEventPlace(eventId);
+        List<Place> partnerStores = eventPlaces.stream()
+                .filter(e -> e.getEventCode() == EventType.GENERAL)
                 .map(EventPlace::getPlace)
-                .filter(Objects::nonNull)
-                .limit(3)
                 .toList();
 
-        List<CouponTemplate> fcfsCoupons = couponTemplateRepository
-                .findByEventIdAndDiscountCode(eventId, DiscountPolicy.COUPON_FCFS);
+        // 4. 선착순 쿠폰 조회
+        List<CouponTemplate> couponList = couponTemplateRepository.findByEventCoupon(eventId, DiscountPolicy.COUPON_FCFS);
 
-        List<EventCouponResponseDto> couponDtos = fcfsCoupons.stream()
-                .filter(c -> popupStore != null && Objects.equals(c.getMarkerCode(), popupStore.getMarkerCode()))
+        List<EventCouponResponseDto> couponDtos = couponList.stream()
                 .map(EventCouponResponseDto::from)
                 .toList();
 
-        return EventDetailResponseDto.of(event, popupStore, generalPlaces, couponDtos);
+        return EventDetailResponseDto.of(event, popupStore, partnerStores, couponDtos);
     }
 }

--- a/src/main/java/com/unear/userservice/place/entity/EventPlace.java
+++ b/src/main/java/com/unear/userservice/place/entity/EventPlace.java
@@ -1,5 +1,6 @@
 package com.unear.userservice.place.entity;
 
+import com.unear.userservice.common.enums.EventType;
 import com.unear.userservice.event.entity.UnearEvent;
 import com.unear.userservice.stamp.entity.Stamp;
 import jakarta.persistence.*;
@@ -25,7 +26,8 @@ public class EventPlace {
     @JoinColumn(name = "place_id")
     private Place place;
 
-    private String eventCode;
+    @Enumerated(EnumType.STRING)
+    private EventType eventCode;
 
     @OneToMany(mappedBy = "eventPlace")
     private List<Stamp> stamps = new ArrayList<>();

--- a/src/main/java/com/unear/userservice/place/repository/EventPlaceRepository.java
+++ b/src/main/java/com/unear/userservice/place/repository/EventPlaceRepository.java
@@ -1,0 +1,29 @@
+package com.unear.userservice.place.repository;
+
+import com.unear.userservice.common.enums.EventType;
+import com.unear.userservice.place.entity.EventPlace;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface EventPlaceRepository extends JpaRepository<EventPlace, Long> {
+    // 팝업스토어 조회
+    @Query("""
+        SELECT ep FROM EventPlace ep
+        WHERE ep.event.unearEventId = :eventId
+        AND ep.eventCode = :eventCode
+    """)
+    List<EventPlace> findByEventPopup(@Param("eventId") Long eventId,
+                                      @Param("eventCode") EventType eventCode);
+
+    // 전체 제휴처 조회 (팝업 포함)
+    @Query("""
+        SELECT ep FROM EventPlace ep
+        WHERE ep.event.unearEventId = :eventId
+    """)
+    List<EventPlace> findByEventPlace(@Param("eventId") Long eventId);
+}


### PR DESCRIPTION
## PR 목적

관리자가 제휴처 선택하는 방식에서 이벤트 지역,반경 내에 있는 제휴처 모두 조회



## 변경 사항

#92 



## 주요 구현 내용

쿠폰템플릿, 이벤트제휴처 ropository 쿼리문 추가
eventserviceimpl 개선



## 테스트 및 동작 화면 (필요 시 첨부)

<img width="1464" height="824" alt="image" src="https://github.com/user-attachments/assets/8edbe3eb-5dd8-41f7-8404-979f75a50edb" />




## 리뷰 시 중점적으로 봐야 할 부분

확장성이 용이한가, 재활용이 가능한 코드인가


## 병합 전 체크리스트

- [x] 로컬 테스트 완료
- [x] Postman 테스트 포함
- [ ] Swagger 동작 확인
- [x] 코드래빗 리뷰 검토
