### PR TITLE
[WL7-54] 이번주니어 매장 조회 ( Refactor store list and coupon response structure in event detail DTO )

### DIFF
--- a/src/main/java/com/unear/userservice/coupon/dto/response/CouponResponseDto.java
+++ b/src/main/java/com/unear/userservice/coupon/dto/response/CouponResponseDto.java
@@ -35,5 +35,8 @@ public class CouponResponseDto {
                 .userCouponId(userCouponId)
                 .build();
     }
-}
 
+    public static CouponResponseDto from(CouponTemplate entity) {
+        return from(entity, null, false, null);
+    }
+}

--- a/src/main/java/com/unear/userservice/event/dto/response/EventDetailResponseDto.java
+++ b/src/main/java/com/unear/userservice/event/dto/response/EventDetailResponseDto.java
@@ -1,12 +1,16 @@
 package com.unear.userservice.event.dto.response;
 
 
+import com.unear.userservice.coupon.dto.response.CouponResponseDto;
+import com.unear.userservice.coupon.entity.CouponTemplate;
 import com.unear.userservice.event.entity.UnearEvent;
+import com.unear.userservice.place.dto.response.PlaceResponseDto;
 import com.unear.userservice.place.entity.Place;
 import lombok.Builder;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 @Builder
@@ -16,31 +20,44 @@ public record EventDetailResponseDto(
         String description,
         BigDecimal latitude,
         BigDecimal longitude,
-        Integer radius,
+        int radius,
         LocalDate startDate,
         LocalDate endDate,
-        EventPlaceResponseDto popupStore,
-        List<EventPlaceResponseDto> partnerStores,
-        List<EventCouponResponseDto> coupons
+        List<PlaceResponseDto> storeList,
+        List<CouponResponseDto> coupons
 ) {
+
     public static EventDetailResponseDto of(
             UnearEvent event,
             Place popupStore,
-            List<Place> partnerPlaces,
-            List<EventCouponResponseDto> coupons
+            List<Place> partnerStores,
+            List<CouponTemplate> coupons
     ) {
-        return EventDetailResponseDto.builder()
-                .eventId(event.getUnearEventId())
-                .eventName(event.getEventName())
-                .description(event.getEventDescription())
-                .latitude(event.getLatitude())
-                .longitude(event.getLongitude())
-                .radius(event.getRadiusMeter())
-                .startDate(event.getStartAt())
-                .endDate(event.getEndAt())
-                .popupStore(popupStore != null ? EventPlaceResponseDto.from(popupStore) : null)
-                .partnerStores(partnerPlaces.stream().map(EventPlaceResponseDto::from).toList())
-                .coupons(coupons)
-                .build();
+        List<PlaceResponseDto> allStores = new ArrayList<>();
+
+        // 필수 매장 먼저
+        allStores.add(PlaceResponseDto.from(popupStore, true));
+
+        // 일반 매장들
+        allStores.addAll(
+                partnerStores.stream()
+                        .map(place -> PlaceResponseDto.from(place, false))
+                        .toList()
+        );
+
+
+        return new EventDetailResponseDto(
+                event.getUnearEventId(),
+                event.getEventName(),
+                event.getEventDescription(),
+                event.getLatitude(),
+                event.getLongitude(),
+                event.getRadiusMeter(),
+                event.getStartAt(),
+                event.getEndAt(),
+                allStores,
+                coupons.stream().map(CouponResponseDto::from).toList()
+        );
     }
+
 }

--- a/src/main/java/com/unear/userservice/event/service/impl/EventServiceImpl.java
+++ b/src/main/java/com/unear/userservice/event/service/impl/EventServiceImpl.java
@@ -50,9 +50,6 @@ public class EventServiceImpl implements EventService {
         // 4. 선착순 쿠폰 조회
         List<CouponTemplate> couponList = couponTemplateRepository.findByEventCoupon(eventId, DiscountPolicy.COUPON_FCFS);
 
-        List<EventCouponResponseDto> couponResponseDtos = couponList.stream()
-                .map(EventCouponResponseDto::from)
-                .toList();
 
         return EventDetailResponseDto.of(event, popupStore, partnerStores, couponList);
     }

--- a/src/main/java/com/unear/userservice/event/service/impl/EventServiceImpl.java
+++ b/src/main/java/com/unear/userservice/event/service/impl/EventServiceImpl.java
@@ -50,10 +50,10 @@ public class EventServiceImpl implements EventService {
         // 4. 선착순 쿠폰 조회
         List<CouponTemplate> couponList = couponTemplateRepository.findByEventCoupon(eventId, DiscountPolicy.COUPON_FCFS);
 
-        List<EventCouponResponseDto> couponDtos = couponList.stream()
+        List<EventCouponResponseDto> couponResponseDtos = couponList.stream()
                 .map(EventCouponResponseDto::from)
                 .toList();
 
-        return EventDetailResponseDto.of(event, popupStore, partnerStores, couponDtos);
+        return EventDetailResponseDto.of(event, popupStore, partnerStores, couponList);
     }
 }


### PR DESCRIPTION
## PR 목적

이번주니어 매장 리스트 조



## 변경 사항

이번주니어 매장 조회시 매장 이름과 설명만 조회되었는데
```
 {
                "placeId": 138,
                "placeName": "GS25 화곡61길점",
                "placeDesc": "대한민국 국가대표 편의점 GS25",
                "address": "서울특별시 강서구 화곡로61길 31, 1층 (등촌동, 3동)",
                "latitude": 37.5600000,
                "longitude": 126.8500000,
                "benefitCategory": "할인",
                "startTime": 0,
                "endTime": 0,
                "categoryCode": "LIFE",
                "markerCode": "FRANCHISE",
                "eventCode": "GENERAL",
                "franchiseName": "GS 25",
                "distanceKm": null,
                "favorite": false
            }
```
이렇게 조회되도록 바꿨습니다.


CouponResponseDto 수정
EventDetailResponseDto 수정
EventServiceImpl 수정

## 주요 구현 내용

#100 
매장 리스트 조회


## 테스트 및 동작 화면 (필요 시 첨부)

<img width="1109" height="882" alt="image" src="https://github.com/user-attachments/assets/17e3358f-addf-4843-8f71-075bdceb7f1f" />



## 리뷰 시 중점적으로 봐야 할 부분

유지보수성이 좋은지, 이식성및 재활용이 용이한 코드인지



## 병합 전 체크리스트

- [x] 로컬 테스트 완료
- [x] Postman 테스트 포함
- [ ] Swagger 동작 확인
- [x] 코드래빗 리뷰 검토
