### PR TITLE
[WL7-320] OAuth 통합 구현

### DIFF
--- a/src/main/java/com/unear/userservice/auth/controller/AuthController.java
+++ b/src/main/java/com/unear/userservice/auth/controller/AuthController.java
@@ -1,22 +1,26 @@
 package com.unear.userservice.auth.controller;
 
+import com.unear.userservice.auth.dto.request.CompleteProfileRequestDto;
 import com.unear.userservice.auth.dto.request.LoginRequestDto;
 import com.unear.userservice.auth.dto.request.ResetPasswordRequestDto;
 import com.unear.userservice.auth.dto.request.SignupRequestDto;
 import com.unear.userservice.auth.dto.response.LoginResponseDto;
 import com.unear.userservice.auth.dto.response.LogoutResponseDto;
+import com.unear.userservice.auth.dto.response.ProfileUpdateResponseDto;
 import com.unear.userservice.auth.dto.response.RefreshResponseDto;
 import com.unear.userservice.auth.dto.response.SignupResponseDto;
 import com.unear.userservice.auth.service.AuthService;
 import com.unear.userservice.auth.service.EmailService;
 import com.unear.userservice.common.response.ApiResponse;
 import com.unear.userservice.common.exception.ErrorCode;
+import com.unear.userservice.common.security.CustomUser;
 import com.unear.userservice.user.repository.UserRepository;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.*;
 
@@ -38,6 +42,15 @@ public class AuthController {
     @PostMapping("/signup")
     public ResponseEntity<ApiResponse<SignupResponseDto>> signup(@Valid @RequestBody SignupRequestDto request) {
         return ResponseEntity.ok(authService.signup(request));
+    }
+
+    @PostMapping("/oauth/complete-profile")
+    public ResponseEntity<ApiResponse<ProfileUpdateResponseDto>> completeOAuthProfile (
+            @AuthenticationPrincipal CustomUser user,
+            @Valid @RequestBody CompleteProfileRequestDto request) {
+
+        Long userId = user.getUser().getUserId();
+        return ResponseEntity.ok(authService.completeOAuthProfile(userId, request));
     }
 
     @PostMapping("/refresh")

--- a/src/main/java/com/unear/userservice/auth/controller/AuthController.java
+++ b/src/main/java/com/unear/userservice/auth/controller/AuthController.java
@@ -87,5 +87,4 @@ public class AuthController {
         return ResponseEntity.ok(ApiResponse.success("비밀번호가 성공적으로 재설정되었습니다."));
     }
 
-
 }

--- a/src/main/java/com/unear/userservice/auth/dto/request/CompleteProfileRequestDto.java
+++ b/src/main/java/com/unear/userservice/auth/dto/request/CompleteProfileRequestDto.java
@@ -1,0 +1,19 @@
+package com.unear.userservice.auth.dto.request;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CompleteProfileRequestDto {
+    private String username;
+
+    private String tel;
+
+    private LocalDateTime birthdate;
+
+    private String gender;
+}

--- a/src/main/java/com/unear/userservice/auth/dto/response/ProfileUpdateResponseDto.java
+++ b/src/main/java/com/unear/userservice/auth/dto/response/ProfileUpdateResponseDto.java
@@ -1,0 +1,34 @@
+package com.unear.userservice.auth.dto.response;
+
+import com.unear.userservice.user.entity.User;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProfileUpdateResponseDto {
+    private Long userId;
+    private String email;
+    private String username;
+    private String tel;
+    private LocalDateTime birthdate;
+    private String gender;
+    private String barcodeNumber;
+    private boolean isProfileComplete;
+
+    public static ProfileUpdateResponseDto from(User user) {
+        return new ProfileUpdateResponseDto(
+                user.getUserId(),
+                user.getEmail(),
+                user.getUsername(),
+                user.getTel(),
+                user.getBirthdate(),
+                user.getGender(),
+                user.getBarcodeNumber(),
+                user.isProfileComplete()
+        );
+    }
+}

--- a/src/main/java/com/unear/userservice/auth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/unear/userservice/auth/handler/OAuth2SuccessHandler.java
@@ -1,7 +1,9 @@
 package com.unear.userservice.auth.handler;
 
+import com.unear.userservice.auth.CookieUtil;
 import com.unear.userservice.auth.dto.response.LoginResponseDto;
 import com.unear.userservice.auth.service.AuthService;
+import com.unear.userservice.common.exception.exception.UserNotFoundException;
 import com.unear.userservice.common.jwt.JwtTokenProvider;
 import com.unear.userservice.common.jwt.RefreshTokenService;
 import com.unear.userservice.common.response.ApiResponse;
@@ -13,6 +15,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.validator.internal.util.stereotypes.Lazy;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
@@ -29,7 +32,6 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
     private final UserRepository userRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenService refreshTokenService;
-    private final AuthService authService;
 
     @Value("${app.frontend.base-url:http://localhost:4000}")
     private String frontendBaseUrl;
@@ -42,15 +44,22 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         String email = oAuth2User.getAttribute("email");
 
         User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new RuntimeException("유저 정보 없음")); // usernotfound 로 바꾸기
+                .orElseThrow(() -> new UserNotFoundException("유저 정보 없음"));
 
-        ApiResponse<LoginResponseDto> loginResponse = authService.oauthLogin(user, response);
-        String accessToken = loginResponse.getData().getAccessToken();
+        CustomUser customUser = new CustomUser(user);
+        String accessToken = jwtTokenProvider.generateAccessToken(customUser);
+        String refreshToken = jwtTokenProvider.generateRefreshToken(customUser);
+
+        refreshTokenService.saveRefreshToken(user.getUserId(), refreshToken);
+
+        Cookie cookie = new Cookie("refreshToken", refreshToken);
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+        response.addCookie(cookie);
 
         String redirectUrl = String.format("%s/login/oauth2/code/google?accessToken=%s",
                 frontendBaseUrl, accessToken);
 
         response.sendRedirect(redirectUrl);
-
     }
 }

--- a/src/main/java/com/unear/userservice/auth/service/AuthService.java
+++ b/src/main/java/com/unear/userservice/auth/service/AuthService.java
@@ -8,10 +8,14 @@ import com.unear.userservice.auth.dto.response.LogoutResponseDto;
 import com.unear.userservice.auth.dto.response.RefreshResponseDto;
 import com.unear.userservice.auth.dto.response.SignupResponseDto;
 import com.unear.userservice.common.response.ApiResponse;
+import com.unear.userservice.user.entity.User;
 import jakarta.servlet.http.HttpServletResponse;
 
 public interface AuthService {
     ApiResponse<LoginResponseDto> login(LoginRequestDto loginRequestDto, HttpServletResponse response);
+
+    ApiResponse<LoginResponseDto> oauthLogin(User user, HttpServletResponse response);
+
 
     ApiResponse<RefreshResponseDto> refresh(String refreshTokenHeader);
 

--- a/src/main/java/com/unear/userservice/auth/service/AuthService.java
+++ b/src/main/java/com/unear/userservice/auth/service/AuthService.java
@@ -1,15 +1,18 @@
 package com.unear.userservice.auth.service;
 
+import com.unear.userservice.auth.dto.request.CompleteProfileRequestDto;
 import com.unear.userservice.auth.dto.request.LoginRequestDto;
 import com.unear.userservice.auth.dto.request.ResetPasswordRequestDto;
 import com.unear.userservice.auth.dto.request.SignupRequestDto;
 import com.unear.userservice.auth.dto.response.LoginResponseDto;
 import com.unear.userservice.auth.dto.response.LogoutResponseDto;
+import com.unear.userservice.auth.dto.response.ProfileUpdateResponseDto;
 import com.unear.userservice.auth.dto.response.RefreshResponseDto;
 import com.unear.userservice.auth.dto.response.SignupResponseDto;
 import com.unear.userservice.common.response.ApiResponse;
 import com.unear.userservice.user.entity.User;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 
 public interface AuthService {
     ApiResponse<LoginResponseDto> login(LoginRequestDto loginRequestDto, HttpServletResponse response);
@@ -25,4 +28,5 @@ public interface AuthService {
 
     void resetPassword(ResetPasswordRequestDto request);
 
+    ApiResponse<ProfileUpdateResponseDto> completeOAuthProfile(Long userId, @Valid CompleteProfileRequestDto request);
 }

--- a/src/main/java/com/unear/userservice/auth/service/impl/GoogleOAuth2UserService.java
+++ b/src/main/java/com/unear/userservice/auth/service/impl/GoogleOAuth2UserService.java
@@ -29,6 +29,11 @@ public class GoogleOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 
         String email = (String) attributes.get("email");
         String name = (String) attributes.get("name");
+        String googleId = (String) attributes.get("sub");
+
+        if (email == null || email.isEmpty()) {
+            throw new OAuth2AuthenticationException("Email not provided by Google");
+        }
 
         User user = userRepository.findByEmail(email)
                 .orElseGet(() -> userRepository.save(

--- a/src/main/java/com/unear/userservice/auth/service/impl/GoogleOAuth2UserService.java
+++ b/src/main/java/com/unear/userservice/auth/service/impl/GoogleOAuth2UserService.java
@@ -1,5 +1,6 @@
 package com.unear.userservice.auth.service.impl;
 
+import com.unear.userservice.common.enums.LoginProvider;
 import com.unear.userservice.user.entity.User;
 import com.unear.userservice.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -41,6 +42,8 @@ public class GoogleOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
                                 .email(email)
                                 .username(name)
                                 .password(null)
+                                .provider(LoginProvider.GOOGLE)
+                                .providerId(googleId)
                                 .tel(null)
                                 .birthdate(null)
                                 .gender(null)

--- a/src/main/java/com/unear/userservice/common/enums/LoginProvider.java
+++ b/src/main/java/com/unear/userservice/common/enums/LoginProvider.java
@@ -1,0 +1,5 @@
+package com.unear.userservice.common.enums;
+
+public enum LoginProvider {
+    EMAIL, GOOGLE, KAKAO, NAVER
+}

--- a/src/main/java/com/unear/userservice/user/entity/User.java
+++ b/src/main/java/com/unear/userservice/user/entity/User.java
@@ -1,6 +1,7 @@
 package com.unear.userservice.user.entity;
 
 import com.unear.userservice.benefit.entity.RouletteResult;
+import com.unear.userservice.common.enums.LoginProvider;
 import com.unear.userservice.coupon.entity.UserCoupon;
 import com.unear.userservice.place.entity.FavoritePlace;
 import com.unear.userservice.stamp.entity.Stamp;
@@ -39,9 +40,10 @@ public class User {
     private String membershipCode;
 
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "provider")
     @Builder.Default
-    private String provider = "EMAIL";
+    private LoginProvider provider = LoginProvider.EMAIL;
 
     @Column(name = "provider_id")
     private String providerId;

--- a/src/main/java/com/unear/userservice/user/entity/User.java
+++ b/src/main/java/com/unear/userservice/user/entity/User.java
@@ -28,6 +28,7 @@ public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long userId;
+
     @Column(name= "name")
     private String username;
     private String password;
@@ -36,16 +37,22 @@ public class User {
     private LocalDateTime birthdate;
     private String gender;
     private String membershipCode;
-    // 이거 로그인한 경로 (네이버인지 구글인지 카카오인지) 구분으로 컬럼 추가해야될거같아요 지금 임시방편으로 @Transient 달아놨습니다
-    @Transient
-    private String provider;
+
+
+    @Column(name = "provider")
+    @Builder.Default
+    private String provider = "EMAIL";
+
+    @Column(name = "provider_id")
+    private String providerId;
 
     @CreatedDate
     private LocalDateTime createdAt;
+
     @LastModifiedDate
     private LocalDateTime updatedAt;
 
-    private boolean isProfileComplete; // oauth 로그인시 추가 정보 입력 완료 여부, true -> oauth
+    private boolean isProfileComplete;
 
     @OneToMany(mappedBy = "user")
     private List<UserCoupon> userCoupons = new ArrayList<>();


### PR DESCRIPTION
## PR 목적 및 변경 사항

**OAuth 2.0 구글 로그인 통합 구현**

- 기존 이메일 로그인과 동일한 JWT 토큰 방식으로 OAuth 통합
- 구글 로그인 시 자동 회원가입 + 추가정보 입력 플로우 구현
- User 엔티티에 loginProvider, providerId 필드 추가로 로그인 방식 구분
- OAuth 유저 프로필 완성 API (/auth/oauth/complete-profile) 추가
- 향후 카카오 등 다른 소셜 로그인 확장 가능한 구조로 설계



## 주요 구현 내용

```mermaid
sequenceDiagram
    participant U as User
    participant F as Frontend
    participant B as Backend
    participant G as Google
    participant DB as Database
    participant R as Redis

    U->>F: 구글 로그인 클릭
    F->>G: OAuth2 인증 요청
    G->>U: 구글 로그인 화면
    U->>G: 로그인 완료
    G->>B: 인증 코드 전달
    
    B->>B: GoogleOAuth2UserService.loadUser()
    B->>G: 사용자 정보 요청
    G->>B: 사용자 정보 반환 (email, name, sub)
    
    alt 신규 유저
        B->>DB: User 생성 (isProfileComplete=false)
    else 기존 유저
        B->>DB: User 조회
    end
    
    B->>B: OAuth2SuccessHandler 실행
    B->>B: AuthService.oauthLogin()
    B->>B: JWT 토큰 생성
    B->>R: RefreshToken 저장
    B->>F: 리다이렉트 + AccessToken
    
    F->>F: User 정보 확인 (isProfileComplete?)
    
    alt 프로필 미완성
        F->>U: 추가정보 입력 화면
        U->>F: 추가정보 입력 (전화번호, 생년월일 등)
        F->>B: POST /auth/oauth/complete-profile
        B->>DB: User 정보 업데이트 (isProfileComplete=true, 바코드 생성)
        B->>F: 프로필 완성 응답
    end
    
    F->>U: 로그인 완료

```



## 병합 전 체크리스트

- [ ] 로컬 테스트 완료
- [ ] Postman 테스트 포함
- [ ] Swagger 동작 확인
- [ ] 코드래빗 리뷰 검토
