### PR TITLE
[WL7-295] 스탬프 조회 ( Add REST API for retrieving user-specific event stamp history )

### DIFF
--- a/src/main/java/com/unear/userservice/stamp/controller/StampController.java
+++ b/src/main/java/com/unear/userservice/stamp/controller/StampController.java
@@ -1,0 +1,30 @@
+package com.unear.userservice.stamp.controller;
+
+import com.unear.userservice.common.response.ApiResponse;
+import com.unear.userservice.stamp.dto.response.StampStatusResponseDto;
+import com.unear.userservice.stamp.service.StampService;
+import com.unear.userservice.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/stamps")
+public class StampController {
+
+    private final StampService stampService;
+
+    @GetMapping("/events/{eventId}")
+    public ResponseEntity<ApiResponse<StampStatusResponseDto>> getStampsByEvent(
+            @AuthenticationPrincipal(expression = "user") User user,
+            @PathVariable Long eventId
+    ) {
+        StampStatusResponseDto result = stampService.getStampStatus(user.getUserId(), eventId);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+}

--- a/src/main/java/com/unear/userservice/stamp/controller/StampController.java
+++ b/src/main/java/com/unear/userservice/stamp/controller/StampController.java
@@ -1,6 +1,7 @@
 package com.unear.userservice.stamp.controller;
 
 import com.unear.userservice.common.response.ApiResponse;
+import com.unear.userservice.common.security.CustomUser;
 import com.unear.userservice.stamp.dto.response.StampStatusResponseDto;
 import com.unear.userservice.stamp.service.StampService;
 import com.unear.userservice.user.entity.User;
@@ -21,10 +22,10 @@ public class StampController {
 
     @GetMapping("/events/{eventId}")
     public ResponseEntity<ApiResponse<StampStatusResponseDto>> getStampsByEvent(
-            @AuthenticationPrincipal(expression = "user") User user,
+            @AuthenticationPrincipal CustomUser customUser,
             @PathVariable Long eventId
     ) {
-        StampStatusResponseDto result = stampService.getStampStatus(user.getUserId(), eventId);
+        StampStatusResponseDto result = stampService.getStampStatus(customUser.getId(), eventId);
         return ResponseEntity.ok(ApiResponse.success(result));
     }
 }

--- a/src/main/java/com/unear/userservice/stamp/domain/EventStampPolicy.java
+++ b/src/main/java/com/unear/userservice/stamp/domain/EventStampPolicy.java
@@ -1,0 +1,14 @@
+package com.unear.userservice.stamp.domain;
+
+import com.unear.userservice.common.enums.EventType;
+
+public class EventStampPolicy {
+
+    private static final int REQUIRED_COUNT = 1;
+    private static final int GENERAL_COUNT = 3;
+
+    public boolean isSatisfiedBy(StampCollection stamps) {
+        return stamps.countByEventType(EventType.REQUIRE) >= REQUIRED_COUNT
+                && stamps.distinctPlaceCountByEventType(EventType.GENERAL) >= GENERAL_COUNT;
+    }
+}

--- a/src/main/java/com/unear/userservice/stamp/domain/StampCollection.java
+++ b/src/main/java/com/unear/userservice/stamp/domain/StampCollection.java
@@ -1,0 +1,35 @@
+package com.unear.userservice.stamp.domain;
+
+import com.unear.userservice.place.entity.Place;
+import com.unear.userservice.stamp.entity.Stamp;
+import com.unear.userservice.common.enums.EventType;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class StampCollection {
+
+    private final List<Stamp> stamps;
+
+    public StampCollection(List<Stamp> stamps) {
+        this.stamps = stamps;
+    }
+
+    public long countByEventType(EventType eventType) {
+        return stamps.stream()
+                .filter(s -> s.getEventPlace().getEventCode() == eventType)
+                .count();
+    }
+
+    public long distinctPlaceCountByEventType(EventType eventType) {
+        return stamps.stream()
+                .filter(s -> s.getEventPlace().getEventCode() == eventType)
+                .map(s -> s.getEventPlace().getPlace().getPlaceId())
+                .distinct()
+                .count();
+    }
+
+    public List<Stamp> getStamps() {
+        return stamps;
+    }
+}

--- a/src/main/java/com/unear/userservice/stamp/domain/StampCollection.java
+++ b/src/main/java/com/unear/userservice/stamp/domain/StampCollection.java
@@ -12,7 +12,7 @@ public class StampCollection {
     private final List<Stamp> stamps;
 
     public StampCollection(List<Stamp> stamps) {
-        this.stamps = stamps;
+        this.stamps = Objects.requireNonNull(stamps, "stamps는 null일 수 없습니다");
     }
 
     public long countByEventType(EventType eventType) {

--- a/src/main/java/com/unear/userservice/stamp/dto/response/StampResponseDto.java
+++ b/src/main/java/com/unear/userservice/stamp/dto/response/StampResponseDto.java
@@ -1,0 +1,30 @@
+package com.unear.userservice.stamp.dto.response;
+
+import com.unear.userservice.common.enums.EventType;
+import com.unear.userservice.stamp.entity.Stamp;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class StampResponseDto {
+    private Long stampId;
+    private String placeName;
+    private EventType eventCode;
+    private LocalDateTime stampedAt;
+
+    public static StampResponseDto from(Stamp stamp) {
+        return new StampResponseDto(
+                stamp.getStampId(),
+                stamp.getPlaceName(),
+                stamp.getEventPlace().getEventCode(),
+                stamp.getStampedAt()
+        );
+    }
+}

--- a/src/main/java/com/unear/userservice/stamp/dto/response/StampResponseDto.java
+++ b/src/main/java/com/unear/userservice/stamp/dto/response/StampResponseDto.java
@@ -20,6 +20,9 @@ public class StampResponseDto {
     private LocalDateTime stampedAt;
 
     public static StampResponseDto from(Stamp stamp) {
+        if (stamp == null || stamp.getEventPlace() == null) {
+            throw new IllegalArgumentException("Stamp and EventPlace cannot be null");
+        }
         return new StampResponseDto(
                 stamp.getStampId(),
                 stamp.getPlaceName(),

--- a/src/main/java/com/unear/userservice/stamp/dto/response/StampStatusResponseDto.java
+++ b/src/main/java/com/unear/userservice/stamp/dto/response/StampStatusResponseDto.java
@@ -1,0 +1,27 @@
+package com.unear.userservice.stamp.dto.response;
+
+import com.unear.userservice.stamp.dto.response.StampResponseDto;
+import com.unear.userservice.stamp.entity.Stamp;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class StampStatusResponseDto {
+    private List<StampResponseDto> stamps;
+    private boolean rouletteAvailable;
+
+    public static StampStatusResponseDto of(List<Stamp> stampList, boolean rouletteAvailable) {
+        List<StampResponseDto> dtoList = stampList.stream()
+                .map(StampResponseDto::from)
+                .toList();
+
+        return new StampStatusResponseDto(dtoList, rouletteAvailable);
+    }
+}

--- a/src/main/java/com/unear/userservice/stamp/repository/StampRepository.java
+++ b/src/main/java/com/unear/userservice/stamp/repository/StampRepository.java
@@ -1,0 +1,12 @@
+package com.unear.userservice.stamp.repository;
+
+import com.unear.userservice.stamp.entity.Stamp;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface StampRepository extends JpaRepository<Stamp, Long> {
+    List<Stamp> findByUser_UserIdAndEventPlace_Event_UnearEventId (Long userId, Long eventPlaceId);
+}

--- a/src/main/java/com/unear/userservice/stamp/repository/StampRepository.java
+++ b/src/main/java/com/unear/userservice/stamp/repository/StampRepository.java
@@ -8,5 +8,5 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface StampRepository extends JpaRepository<Stamp, Long> {
-    List<Stamp> findByUser_UserIdAndEventPlace_Event_UnearEventId (Long userId, Long eventPlaceId);
+    List<Stamp> findByUser_UserIdAndEventPlace_Event_UnearEventId (Long userId, Long eventId);
 }

--- a/src/main/java/com/unear/userservice/stamp/service/StampService.java
+++ b/src/main/java/com/unear/userservice/stamp/service/StampService.java
@@ -1,0 +1,7 @@
+package com.unear.userservice.stamp.service;
+
+import com.unear.userservice.stamp.dto.response.StampStatusResponseDto;
+
+public interface StampService {
+    StampStatusResponseDto getStampStatus(Long userId, Long eventId);
+}

--- a/src/main/java/com/unear/userservice/stamp/service/impl/StampServiceImpl.java
+++ b/src/main/java/com/unear/userservice/stamp/service/impl/StampServiceImpl.java
@@ -1,0 +1,31 @@
+package com.unear.userservice.stamp.service.impl;
+
+import com.unear.userservice.stamp.domain.EventStampPolicy;
+import com.unear.userservice.stamp.domain.StampCollection;
+import com.unear.userservice.stamp.dto.response.StampStatusResponseDto;
+import com.unear.userservice.stamp.entity.Stamp;
+import com.unear.userservice.stamp.repository.StampRepository;
+import com.unear.userservice.stamp.service.StampService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+public class StampServiceImpl implements StampService {
+
+    private final StampRepository stampRepository;
+
+    @Override
+    public StampStatusResponseDto getStampStatus(Long userId, Long eventId) {
+        List<Stamp> stamps = stampRepository.findByUser_UserIdAndEventPlace_Event_UnearEventId(userId, eventId);
+        StampCollection collection = new StampCollection(stamps);
+        EventStampPolicy policy = new EventStampPolicy();
+
+        boolean available = policy.isSatisfiedBy(collection);
+        return StampStatusResponseDto.of(collection.getStamps(), available);
+    }
+}

--- a/src/main/java/com/unear/userservice/stamp/service/impl/StampServiceImpl.java
+++ b/src/main/java/com/unear/userservice/stamp/service/impl/StampServiceImpl.java
@@ -21,10 +21,12 @@ public class StampServiceImpl implements StampService {
 
     @Override
     public StampStatusResponseDto getStampStatus(Long userId, Long eventId) {
+        if (userId == null || eventId == null) {
+            throw new IllegalArgumentException("userId와 eventId는 null일 수 없습니다");
+        }
         List<Stamp> stamps = stampRepository.findByUser_UserIdAndEventPlace_Event_UnearEventId(userId, eventId);
         StampCollection collection = new StampCollection(stamps);
         EventStampPolicy policy = new EventStampPolicy();
-
         boolean available = policy.isSatisfiedBy(collection);
         return StampStatusResponseDto.of(collection.getStamps(), available);
     }


### PR DESCRIPTION
## PR 목적

스탬프 조회 기능
필수 매장1개 + 이벤트제휴처3개 충족이 되면 룰렛에 true 반환


## 변경 사항

#48 



## 주요 구현 내용

스탬프 내역 조회
stamp 패키지 하위 controller, responseDto, repository, service 구현


## 테스트 및 동작 화면 (필요 시 첨부)

## 임의로 데이터베이스에 넣은값을 조회했습니다.
<img width="1480" height="909" alt="image" src="https://github.com/user-attachments/assets/52775371-68ff-4b37-a982-fe3838e26536" />



## 리뷰 시 중점적으로 봐야 할 부분

여기서 
유저가 로그인을함 -> 유저가 제휴처를 감 -> 제휴처에서 물건을 사던 먹던 하고 멤버십 바코드를 찍음 (중요) -> 이후 이벤트 지역내 이벤트 제휴처이면 스탬프가 쌓임 -> 이번주니어 페이지에서 조회 해당 흐름으로 서비스가 되어야 합니다.



## 병합 전 체크리스트

- [ ] 로컬 테스트 완료
- [ ] Postman 테스트 포함
- [ ] Swagger 동작 확인
- [ ] 코드래빗 리뷰 검토
