### PR TITLE
[Wl7-42] 장소 상세조회, 근처 장소 조회

### DIFF
--- a/src/main/java/com/unear/userservice/benefit/controller/DiscountPolicyController.java
+++ b/src/main/java/com/unear/userservice/benefit/controller/DiscountPolicyController.java
@@ -24,9 +24,9 @@ public class DiscountPolicyController {
     private final DiscountPolicyService discountPolicyService;
 
     @BenefitApiDocs.GetGeneralDiscountPolicyDetail
-    @GetMapping("/{id}")
+    @GetMapping("/{discount_policy_detail_id}")
     public ResponseEntity<ApiResponse<GeneralDiscountPolicyDetailResponseDto>> getDiscountPolicyDetail(
-            @PathVariable("id") Long discountPolicyDetailId
+            @PathVariable("discount_policy_detail_id") Long discountPolicyDetailId
     ) {
         GeneralDiscountPolicyDetailResponseDto response = discountPolicyService.getDiscountPolicyDetail(discountPolicyDetailId);
         return ResponseEntity.ok(ApiResponse.success("혜택 상세 조회 성공", response));
@@ -42,9 +42,9 @@ public class DiscountPolicyController {
     }
 
     @BenefitApiDocs.GetFranchiseDiscountPolicyDetail
-    @GetMapping("/franchise/{id}")
+    @GetMapping("/franchise/{franchise_id}")
     public ResponseEntity<ApiResponse<FranchiseDiscountPolicyDetailResponseDto>> getFranchiseDiscountPolicyDetail(
-            @PathVariable("id") Long franchiseId
+            @PathVariable("franchise_id") Long franchiseId
     ) {
         FranchiseDiscountPolicyDetailResponseDto response = discountPolicyService.getFranchiseDiscountPolicyDetail(franchiseId);
         return ResponseEntity.ok(ApiResponse.success("프랜차이즈 혜택 상세 조회 성공", response));

--- a/src/main/java/com/unear/userservice/benefit/repository/FranchiseDiscountPolicyRepository.java
+++ b/src/main/java/com/unear/userservice/benefit/repository/FranchiseDiscountPolicyRepository.java
@@ -13,4 +13,5 @@ public interface FranchiseDiscountPolicyRepository extends JpaRepository<Franchi
     @Query("SELECT f.franchiseDiscountPolicyId FROM FranchiseDiscountPolicy f WHERE f.franchise.franchiseId = :franchiseId")
     List<Long> findPolicyIdsByFranchiseId(@Param("franchiseId") Long franchiseId);
 
+    List<FranchiseDiscountPolicy> findByFranchise_FranchiseId(Long franchiseId);
 }

--- a/src/main/java/com/unear/userservice/benefit/repository/GeneralDiscountPolicyRepository.java
+++ b/src/main/java/com/unear/userservice/benefit/repository/GeneralDiscountPolicyRepository.java
@@ -1,6 +1,7 @@
 package com.unear.userservice.benefit.repository;
 
 import com.unear.userservice.benefit.entity.GeneralDiscountPolicy;
+import com.unear.userservice.place.entity.Place;
 import org.springframework.data.repository.query.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
@@ -23,6 +24,7 @@ public interface GeneralDiscountPolicyRepository extends JpaRepository<GeneralDi
     @Query("SELECT p.generalDiscountPolicyId FROM GeneralDiscountPolicy p WHERE p.place.placeId = :placeId")
     List<Long> findPolicyIdsByPlaceId(@Param("placeId") Long placeId);
 
+    List<GeneralDiscountPolicy> findByPlaceIn(List<Place> places);
 }
 
 

--- a/src/main/java/com/unear/userservice/common/docs/place/PlaceApiDocs.java
+++ b/src/main/java/com/unear/userservice/common/docs/place/PlaceApiDocs.java
@@ -31,28 +31,42 @@ public class PlaceApiDocs {
                                     name = "DefaultFilter",
                                     summary = "사용자의 위도,경도를 기준으로 장소 상세정보 조회",
                                     value = """
-                                            {
-                                                "resultCode": 200,
-                                                "codeName": "SUCCESS",
-                                                "message": "장소 조회 성공",
-                                                "data": {
-                                                    "placeId": 127,
-                                                    "placeName": "파리바게뜨 강서점",
-                                                    "placeDesc": "파리바게뜨 강서점입니다",
-                                                    "address": "서울특별시 강서구 남부순환로 190 (외발산동,외 2필지 (지하 2층))",
-                                                    "latitude": 37.55,
-                                                    "longitude": 126.82,
-                                                    "benefitCategory": "할인",
-                                                    "startTime": 9,
-                                                    "endTime": 20,
-                                                    "categoryCode": "BAKERY",
-                                                    "markerCode": "FRANCHISE",
-                                                    "eventCode": "1",
-                                                    "franchiseName": "파리바게뜨",
-                                                    "distanceKm": 0.9,
-                                                    "favorite": false
+                                    {
+                                        "resultCode": 200,
+                                        "codeName": "SUCCESS",
+                                        "message": "장소 조회 성공",
+                                        "data": {
+                                            "placeId": 132,
+                                            "name": "GS THE FRESH 방화점",
+                                            "address": "서울특별시 강서구 양천로 19, 1층 104호 (방화동, 1동)",
+                                            "categoryCode": "SHOPPING",
+                                            "distanceKm": 3.9,
+                                            "latitude": 37.5800000,
+                                            "longitude": 126.8200000,
+                                            "startTime": 9,
+                                            "endTime": 20,
+                                            "favorite": false,
+                                            "markerCode": "FRANCHISE",
+                                            "eventTypeCode": "NONE",
+                                            "tel": "080-855-5525",
+                                            "discountPolicyDetailId": null,
+                                            "franchiseId": 6,
+                                            "benefitDesc": "3,000원 금액 할인 쿠폰 증정",
+                                            "coupons": [
+                                                {
+                                                    "couponTemplateId": 291,
+                                                    "couponName": "GS THE FRESH VIP 쿠폰",
+                                                    "discountCode": "COUPON_FIXED",
+                                                    "membershipCode": "VIP",
+                                                    "discountInfo": null,
+                                                    "couponStart": "2025-07-01T00:00:00",
+                                                    "couponEnd": "2025-07-31T00:00:00",
+                                                    "userCouponId": null,
+                                                    "downloaded": false
                                                 }
-                                            }
+                                            ]
+                                        }
+                                    }
                 """
                             ),
                             @ExampleObject(
@@ -418,7 +432,7 @@ public class PlaceApiDocs {
     @Operation(
             summary = "가까운장소 및 쿠폰 템플릿 조회",
             description = "사용자의 위도 경도를 기준으로 가까운장소 및 쿠폰 템플릿 조회합니다. 현재 coupon_template이 없는 장소는 coupons가 비어져있는 상태로 반환됩니다. \n"
-            +"downloaded == true 인 쿠폰은 현재 사용자가 다운받은 상태입니다. 쿠폰 상세조회시에는 userCouponId를 사용하면됩니다. "
+            +"downloaded == true 인 쿠폰은 현재 사용자가 다운받은 상태입니다. benefitDesc == null 인 곳은 할인헤택이 따로 존재하지않는 장소입니다"
     )
     @ApiResponse(
             responseCode = "200",
@@ -429,67 +443,134 @@ public class PlaceApiDocs {
                     examples = {
                             @ExampleObject(
                                     name = "DefaultFilter",
-                                    summary = "사용자의 즐겨찾기 장소 목록을 반환",
+                                    summary = "사용자 기준으로 가까운장소 및 쿠폰 템플릿 조회",
                                     value = """
-                                    {
-                                        "resultCode": 200,
-                                        "codeName": "SUCCESS",
-                                        "message": "주변 매장 및 쿠폰 조회 성공",
-                                        "data": [
                                             {
-                                                "placeId": 127,
-                                                "name": "파리바게뜨 강서점",
-                                                "address": "서울특별시 강서구 남부순환로 190 (외발산동,외 2필지 (지하 2층))",
-                                                "categoryCode": "BAKERY",
-                                                "distanceKm": 0.9,
-                                                "coupons": []
-                                            },
-                                            {
-                                                "placeId": 133,
-                                                "name": "GS25 강서희망점",
-                                                "address": "서울특별시 강서구 남부순환로 222, 사무동 (외발산동,서울자동차학원 (지상 1층))",
-                                                "categoryCode": "LIFE",
-                                                "distanceKm": 0.9,
-                                                "coupons": []
-                                            },
-                                            {
-                                                "placeId": 201,
-                                                "name": "파리크라상 공항동점",
-                                                "address": "서울특별시 강서구 오정로 443-83, 지하 1층 (오쇠동, 공항동)",
-                                                "categoryCode": "BAKERY",
-                                                "distanceKm": 1.0,
-                                                "coupons": []
-                                            },
-                                            {
-                                                "placeId": 128,
-                                                "name": "파리바게뜨 성서점",
-                                                "address": "서울특별시 강서구 방화동로 지하 30, 공항시장역(9호선) 지하 1층 (공항동)",
-                                                "categoryCode": "BAKERY",
-                                                "distanceKm": 1.6,
-                                                "coupons": []
-                                            },
-                                            {
-                                                "placeId": 209,
-                                                "name": "미스터피자 화곡시장점",
-                                                "address": "서울특별시 강서구 강서로45길 45, 1층 102호 (화곡동, 3동)",
-                                                "categoryCode": "FOOD",
-                                                "distanceKm": 1.8,
-                                                "coupons": [
+                                                "resultCode": 200,
+                                                "codeName": "SUCCESS",
+                                                "message": "주변 매장 및 쿠폰 조회 성공",
+                                                "data": [
                                                     {
-                                                        "couponTemplateId": 43,
-                                                        "couponName": "미스터피자 VIP 쿠폰",
-                                                        "discountCode": "COUPON_FIXED",
-                                                        "membershipCode": "VIP",
-                                                        "discountInfo": null,
-                                                        "couponStart": "2025-07-01T00:00:00",
-                                                        "couponEnd": "2025-07-31T00:00:00",
-                                                        "userCouponId": 10,
-                                                        "downloaded": true
+                                                        "placeId": 158,
+                                                        "name": "롯데월드 어드벤처 부산",
+                                                        "address": "부산 기장군 기장읍 동부산관광로 42",
+                                                        "categoryCode": "ACTIVITY",
+                                                        "distanceKm": 0.0,
+                                                        "latitude": 35.1900000,
+                                                        "longitude": 129.2100000,
+                                                        "startTime": 9,
+                                                        "endTime": 20,
+                                                        "favorite": false,
+                                                        "markerCode": "BASIC",
+                                                        "eventTypeCode": "NONE",
+                                                        "tel": "1600-2000",
+                                                        "discountPolicyDetailId": 12,
+                                                        "franchiseId": null,
+                                                        "benefitDesc": "25% 할인 쿠폰 증정 (최대 25,000원 할인)",
+                                                        "coupons": [
+                                                            {
+                                                                "couponTemplateId": 54,
+                                                                "couponName": "롯데월드 어드벤처 부산 전용 쿠폰",
+                                                                "discountCode": "COUPON_PERCENT",
+                                                                "membershipCode": "ALL",
+                                                                "discountInfo": null,
+                                                                "couponStart": "2025-07-01T00:00:00",
+                                                                "couponEnd": "2025-07-31T00:00:00",
+                                                                "userCouponId": null,
+                                                                "downloaded": false
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "placeId": 406,
+                                                        "name": "원더빌리지",
+                                                        "address": "경기 고양시 덕양구 고양대로 1955 3층 원더빌리지",
+                                                        "categoryCode": "ACTIVITY",
+                                                        "distanceKm": 4.9,
+                                                        "latitude": 35.1600000,
+                                                        "longitude": 129.1700000,
+                                                        "startTime": 9,
+                                                        "endTime": 20,
+                                                        "favorite": false,
+                                                        "markerCode": "BASIC",
+                                                        "eventTypeCode": "NONE",
+                                                        "tel": "031-5173-3455",
+                                                        "discountPolicyDetailId": null,
+                                                        "franchiseId": null,
+                                                        "benefitDesc": null,
+                                                        "coupons": []
+                                                    },
+                                                    {
+                                                        "placeId": 147,
+                                                        "name": "클럽디 오아시스",
+                                                        "address": "부산 해운대구 달맞이길 30 엘시티",
+                                                        "categoryCode": "ACTIVITY",
+                                                        "distanceKm": 4.9,
+                                                        "latitude": 35.1600000,
+                                                        "longitude": 129.1700000,
+                                                        "startTime": 9,
+                                                        "endTime": 20,
+                                                        "favorite": false,
+                                                        "markerCode": "BASIC",
+                                                        "eventTypeCode": "NONE",
+                                                        "tel": "080-855-5523",
+                                                        "discountPolicyDetailId": 1,
+                                                        "franchiseId": null,
+                                                        "benefitDesc": "10% 할인 쿠폰 증정 (최대 10,000원 할인)",
+                                                        "coupons": [
+                                                            {
+                                                                "couponTemplateId": 52,
+                                                                "couponName": "클럽디 오아시스 전용 쿠폰",
+                                                                "discountCode": "COUPON_PERCENT",
+                                                                "membershipCode": "ALL",
+                                                                "discountInfo": null,
+                                                                "couponStart": "2025-07-01T00:00:00",
+                                                                "couponEnd": "2025-07-31T00:00:00",
+                                                                "userCouponId": null,
+                                                                "downloaded": false
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "placeId": 359,
+                                                        "name": "바다횟집",
+                                                        "address": "부산시 해운대구 구남로41번길 15",
+                                                        "categoryCode": "FOOD",
+                                                        "distanceKm": 5.1,
+                                                        "latitude": 35.1700000,
+                                                        "longitude": 129.1600000,
+                                                        "startTime": 9,
+                                                        "endTime": 20,
+                                                        "favorite": false,
+                                                        "markerCode": "LOCAL",
+                                                        "eventTypeCode": "NONE",
+                                                        "tel": "0507-1346-7177\\n",
+                                                        "discountPolicyDetailId": 70,
+                                                        "franchiseId": null,
+                                                        "benefitDesc": "멤버십 혜택: 1,000원당 100원 할인",
+                                                        "coupons": []
+                                                    },
+                                                    {
+                                                        "placeId": 356,
+                                                        "name": "수산물직판장태화점",
+                                                        "address": "울산 중구 오산4길 15, 1층",
+                                                        "categoryCode": "FOOD",
+                                                        "distanceKm": 5.6,
+                                                        "latitude": 35.1600000,
+                                                        "longitude": 129.1600000,
+                                                        "startTime": 9,
+                                                        "endTime": 20,
+                                                        "favorite": false,
+                                                        "markerCode": "LOCAL",
+                                                        "eventTypeCode": "NONE",
+                                                        "tel": "052-222-8192\\n",
+                                                        "discountPolicyDetailId": 67,
+                                                        "franchiseId": null,
+                                                        "benefitDesc": "멤버십 혜택: 1,000원당 100원 할인",
+                                                        "coupons": []
                                                     }
                                                 ]
                                             }
-                                        ]
-                                    }
                 """
                             )
                     }

--- a/src/main/java/com/unear/userservice/common/enums/DiscountPolicy.java
+++ b/src/main/java/com/unear/userservice/common/enums/DiscountPolicy.java
@@ -28,5 +28,26 @@ public enum DiscountPolicy {
                 .findFirst()
                 .orElseThrow(() -> new InvalidCodeException("Invalid DiscountPolicy code: " + code));
     }
+
+    public boolean isMembershipFixed() {
+        return this == MEMBERSHIP_FIXED;
+    }
+
+    public boolean isCouponFixed() {
+        return this == COUPON_FIXED;
+    }
+
+    public boolean isCouponPercent() {
+        return this == COUPON_PERCENT;
+    }
+
+    public boolean isMembershipUnit() {
+        return this == MEMBERSHIP_UNIT;
+    }
+
+    public boolean isCouponFCFS() {
+        return this == COUPON_FCFS;
+    }
+
 }
 

--- a/src/main/java/com/unear/userservice/coupon/repository/CouponTemplateRepository.java
+++ b/src/main/java/com/unear/userservice/coupon/repository/CouponTemplateRepository.java
@@ -24,7 +24,7 @@ List<CouponTemplate> findByEventCoupon(
     @Param("discountCode") DiscountPolicy discountPolicy  
 );
 
-@Query("""
+    @Query("""
 SELECT ct FROM CouponTemplate ct
 WHERE (
     ct.markerCode = 'FRANCHISE'
@@ -32,7 +32,7 @@ WHERE (
         SELECT fdp.franchiseDiscountPolicyId
         FROM FranchiseDiscountPolicy fdp
         WHERE fdp.franchise IN :franchises
-          AND fdp.membershipCode = :membershipCode
+          AND (fdp.membershipCode = :membershipCode OR fdp.membershipCode = 'ALL')
     )
 ) OR (
     ct.markerCode != 'FRANCHISE'
@@ -40,15 +40,16 @@ WHERE (
         SELECT gdp.generalDiscountPolicyId
         FROM GeneralDiscountPolicy gdp
         WHERE gdp.place IN :places
-          AND gdp.membershipCode = :membershipCode
+          AND (gdp.membershipCode = :membershipCode OR gdp.membershipCode = 'ALL')
     )
 )
 """)
-List<CouponTemplate> findByPlacesAndMembership(
-    @Param("places") List<Place> places,
-    @Param("franchises") List<Franchise> franchises,
-    @Param("membershipCode") String membershipCode
-);
+    List<CouponTemplate> findByPlacesAndMembership(
+            @Param("places") List<Place> places,
+            @Param("franchises") List<Franchise> franchises,
+            @Param("membershipCode") String membershipCode
+    );
+
 
 
 }

--- a/src/main/java/com/unear/userservice/coupon/service/impl/CouponServiceImpl.java
+++ b/src/main/java/com/unear/userservice/coupon/service/impl/CouponServiceImpl.java
@@ -172,29 +172,31 @@ public class CouponServiceImpl implements CouponService {
                 .map(uc -> {
                     CouponTemplate template = uc.getCouponTemplate();
                     String markerCode = template != null ? template.getMarkerCode() : null;
+                    Long policyId = (template != null) ? template.getDiscountPolicyDetailId() : null;
 
-                    Long policyId = template.getDiscountPolicyDetailId();
                     GeneralDiscountPolicy generalPolicy = null;
                     FranchiseDiscountPolicy franchisePolicy = null;
                     Franchise franchise = null;
                     Place place = null;
-                    PlaceType placeType = PlaceType.fromCode(markerCode);
 
-                    if (placeType.isFranchise()) {
-                        franchisePolicy = franchiseDiscountPolicyRepository.findById(policyId).orElse(null);
-                        franchise = franchisePolicy != null ? franchisePolicy.getFranchise() : null;
-                    } else {
-                        generalPolicy = generalDiscountPolicyRepository.findById(policyId).orElse(null);
-                        place = generalPolicy != null ? generalPolicy.getPlace() : null;
+                    if (markerCode != null && policyId != null) {
+                        PlaceType placeType = PlaceType.fromCode(markerCode);
+                        if (placeType.isFranchise()) {
+                            franchisePolicy = franchiseDiscountPolicyRepository.findById(policyId).orElse(null);
+                            franchise = franchisePolicy != null ? franchisePolicy.getFranchise() : null;
+                        } else {
+                            generalPolicy = generalDiscountPolicyRepository.findById(policyId).orElse(null);
+                            place = generalPolicy != null ? generalPolicy.getPlace() : null;
+                        }
                     }
 
                     return UserCouponResponseDto.builder()
                             .userCouponId(uc.getUserCouponId())
-                            .couponName(template.getCouponName())
+                            .couponName(template != null ? template.getCouponName() : null)
                             .barcodeNumber(uc.getBarcodeNumber())
                             .couponStatusCode(uc.getCouponStatusCode())
                             .createdAt(uc.getCreatedAt())
-                            .couponEnd(template.getCouponEnd())
+                            .couponEnd(template != null ? template.getCouponEnd() : null)
                             .name(resolveFranchiseName(place, franchise))
                             .imageUrl(franchise != null ? franchise.getImageUrl() : null)
                             .categoryCode(
@@ -208,6 +210,7 @@ public class CouponServiceImpl implements CouponService {
 
         return new UserCouponListResponseDto(dtoList);
     }
+
 
     private String resolveFranchiseName(Place place, Franchise franchise) {
         if (franchise != null) {

--- a/src/main/java/com/unear/userservice/place/controller/PlaceController.java
+++ b/src/main/java/com/unear/userservice/place/controller/PlaceController.java
@@ -32,13 +32,13 @@ public class PlaceController {
 
     @PlaceApiDocs.GetPlace
     @GetMapping("/{placeId}")
-    public ResponseEntity<ApiResponse<PlaceResponseDto>> getPlace(
+    public ResponseEntity<ApiResponse<NearbyPlaceWithCouponsDto>> getPlace(
             @PathVariable Long placeId,
             @Valid @ParameterObject @ModelAttribute NearbyPlaceRequestDto location,
             @AuthenticationPrincipal CustomUser user
     ) {
         Long userId = (user != null && user.getUser() != null) ? user.getUser().getUserId() : null;
-        PlaceResponseDto dto = placeService.getPlaceDetail(placeId, userId, location.getLatitude(), location.getLongitude());
+        NearbyPlaceWithCouponsDto dto = placeService.getPlaceDetail(placeId, userId, location.getLatitude(), location.getLongitude());
         return ResponseEntity.ok(ApiResponse.success("장소 조회 성공",dto));
     }
 

--- a/src/main/java/com/unear/userservice/place/dto/response/NearbyPlaceWithCouponsDto.java
+++ b/src/main/java/com/unear/userservice/place/dto/response/NearbyPlaceWithCouponsDto.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 @Getter
@@ -19,6 +20,20 @@ public class NearbyPlaceWithCouponsDto {
     private String address;
     private String categoryCode;
     private Double distanceKm;
+
+    private BigDecimal latitude;
+    private BigDecimal longitude;
+    private Integer startTime;
+    private Integer endTime;
+    private Boolean favorite;
+    private String markerCode;
+    private String eventTypeCode;
+    private String tel;
+
+    private Long discountPolicyDetailId;
+    private Long franchiseId;
+
+    private String benefitDesc;
 
     private List<CouponResponseDto> coupons;
 }

--- a/src/main/java/com/unear/userservice/place/entity/Place.java
+++ b/src/main/java/com/unear/userservice/place/entity/Place.java
@@ -35,6 +35,7 @@ public class Place {
     private String categoryCode;
     private String markerCode;
     private String eventTypeCode;
+    private String tel;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "franchise_id")

--- a/src/main/java/com/unear/userservice/place/service/PlaceService.java
+++ b/src/main/java/com/unear/userservice/place/service/PlaceService.java
@@ -12,7 +12,7 @@ import java.util.List;
 public interface PlaceService {
 
     List<PlaceRenderResponseDto> getFilteredPlaces(PlaceRequestDto requestDto, Long userId);
-    PlaceResponseDto getPlaceDetail(Long placeId, Long userId, Double latitude, Double longitude);
+    NearbyPlaceWithCouponsDto getPlaceDetail(Long placeId, Long userId, Double latitude, Double longitude);
     boolean toggleFavorite(Long userId, Long placeId);
     List<PlaceResponseDto> getUserFavoritePlaces(Long userId);
     List<NearestPlaceResponseDto> getNearbyPlaces(NearbyPlaceRequestDto requestDto, Long userId);

--- a/src/main/java/com/unear/userservice/place/service/impl/BenefitDescriptionResolver.java
+++ b/src/main/java/com/unear/userservice/place/service/impl/BenefitDescriptionResolver.java
@@ -4,6 +4,7 @@ import com.unear.userservice.benefit.entity.FranchiseDiscountPolicy;
 import com.unear.userservice.benefit.entity.GeneralDiscountPolicy;
 import com.unear.userservice.benefit.repository.FranchiseDiscountPolicyRepository;
 import com.unear.userservice.benefit.repository.GeneralDiscountPolicyRepository;
+import com.unear.userservice.common.enums.DiscountPolicy;
 import com.unear.userservice.common.enums.PlaceType;
 import com.unear.userservice.coupon.entity.CouponTemplate;
 import com.unear.userservice.place.entity.Place;
@@ -44,7 +45,8 @@ public class BenefitDescriptionResolver {
                     return percent + "% 할인 쿠폰 증정";
                 } else if (fixed != null) {
                     String discountCode = matchedPolicy.getDiscountCode();
-                    if ("MEMBERSHIP_FIXED".equals(discountCode)) {
+                    DiscountPolicy discountPolicy = DiscountPolicy.fromCode(discountCode);
+                    if (discountPolicy.isMembershipFixed()) {
                         return "멤버십 혜택: " + numberFormat.format(fixed) + "원 할인";
                     } else {
                         return numberFormat.format(fixed) + "원 금액 할인 쿠폰 증정";
@@ -72,7 +74,8 @@ public class BenefitDescriptionResolver {
                     return percent + "% 할인 쿠폰 증정";
                 } else if (fixed != null) {
                     String discountCode = policy.getDiscountCode();
-                    if ("MEMBERSHIP_FIXED".equals(discountCode)) {
+                    DiscountPolicy discountPolicy = DiscountPolicy.fromCode(discountCode);
+                    if (discountPolicy.isMembershipFixed()) {
                         return "멤버십 혜택: " + numberFormat.format(fixed) + "원 할인";
                     } else {
                         return numberFormat.format(fixed) + "원 금액 할인 쿠폰 증정";

--- a/src/main/java/com/unear/userservice/place/service/impl/BenefitDescriptionResolver.java
+++ b/src/main/java/com/unear/userservice/place/service/impl/BenefitDescriptionResolver.java
@@ -1,0 +1,119 @@
+package com.unear.userservice.place.service.impl;
+
+import com.unear.userservice.benefit.entity.FranchiseDiscountPolicy;
+import com.unear.userservice.benefit.entity.GeneralDiscountPolicy;
+import com.unear.userservice.benefit.repository.FranchiseDiscountPolicyRepository;
+import com.unear.userservice.benefit.repository.GeneralDiscountPolicyRepository;
+import com.unear.userservice.common.enums.PlaceType;
+import com.unear.userservice.coupon.entity.CouponTemplate;
+import com.unear.userservice.place.entity.Place;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.text.NumberFormat;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class BenefitDescriptionResolver {
+
+    private final FranchiseDiscountPolicyRepository franchiseDiscountPolicyRepository;
+    private final GeneralDiscountPolicyRepository generalDiscountPolicyRepository;
+
+    public String resolveBenefitDesc(PlaceServiceImpl.DiscountPolicyRef policyRef, String membershipCode) {
+        NumberFormat numberFormat = NumberFormat.getInstance();
+
+        if (policyRef != null && policyRef.franchiseId() != null) {
+            List<FranchiseDiscountPolicy> policies = franchiseDiscountPolicyRepository
+                    .findByFranchise_FranchiseId(policyRef.franchiseId());
+
+            FranchiseDiscountPolicy matchedPolicy = policies.stream()
+                    .filter(p1 -> p1.getMembershipCode().equalsIgnoreCase(membershipCode))
+                    .findFirst()
+                    .orElse(null);
+
+            if (matchedPolicy != null) {
+                Integer percent = matchedPolicy.getDiscountPercent();
+                Integer max = matchedPolicy.getMaxDiscountAmount();
+                Integer fixed = matchedPolicy.getFixedDiscount();
+                Integer unit = matchedPolicy.getUnitBaseAmount();
+
+                if (percent != null && max != null) {
+                    return percent + "% 할인 쿠폰 증정 (최대 " + numberFormat.format(max) + "원 할인)";
+                } else if (percent != null) {
+                    return percent + "% 할인 쿠폰 증정";
+                } else if (fixed != null) {
+                    String discountCode = matchedPolicy.getDiscountCode();
+                    if ("MEMBERSHIP_FIXED".equals(discountCode)) {
+                        return "멤버십 혜택: " + numberFormat.format(fixed) + "원 할인";
+                    } else {
+                        return numberFormat.format(fixed) + "원 금액 할인 쿠폰 증정";
+                    }
+                } else if (unit != null) {
+                    return "멤버십 혜택: 1,000원당 " + numberFormat.format(unit) + "원 할인";
+                } else {
+                    return "기본 멤버십 혜택 제공";
+                }
+            }
+
+        } else if (policyRef != null && policyRef.discountPolicyDetailId() != null) {
+            GeneralDiscountPolicy policy = generalDiscountPolicyRepository.findById(policyRef.discountPolicyDetailId())
+                    .orElse(null);
+
+            if (policy != null) {
+                Integer percent = policy.getDiscountPercent();
+                Integer max = policy.getMaxDiscountAmount();
+                Integer fixed = policy.getFixedDiscount();
+                Integer unit = policy.getUnitBaseAmount();
+
+                if (percent != null && max != null) {
+                    return percent + "% 할인 쿠폰 증정 (최대 " + numberFormat.format(max) + "원 할인)";
+                } else if (percent != null) {
+                    return percent + "% 할인 쿠폰 증정";
+                } else if (fixed != null) {
+                    String discountCode = policy.getDiscountCode();
+                    if ("MEMBERSHIP_FIXED".equals(discountCode)) {
+                        return "멤버십 혜택: " + numberFormat.format(fixed) + "원 할인";
+                    } else {
+                        return numberFormat.format(fixed) + "원 금액 할인 쿠폰 증정";
+                    }
+                } else if (unit != null) {
+                    return "멤버십 혜택: 1,000원당 " + numberFormat.format(unit) + "원 할인";
+                } else {
+                    return "기본 멤버십 혜택 제공";
+                }
+            }
+        }
+
+        return null;
+    }
+
+
+
+    public List<Long> resolvePlaceIdFromTemplateList(CouponTemplate ct, List<Place> places) {
+        PlaceType markerType = PlaceType.fromCode(ct.getMarkerCode());
+
+        if (markerType.isFranchise()) {
+            Long policyId = ct.getDiscountPolicyDetailId();
+            if (policyId == null) return List.of();
+
+            Long franchiseId = franchiseDiscountPolicyRepository.findById(policyId)
+                    .map(f -> f.getFranchise().getFranchiseId())
+                    .orElse(null);
+
+            if (franchiseId == null) return List.of();
+
+            return places.stream()
+                    .filter(p -> p.getFranchise() != null && p.getFranchise().getFranchiseId().equals(franchiseId))
+                    .map(Place::getPlaceId)
+                    .toList();
+
+        } else {
+            return generalDiscountPolicyRepository.findById(ct.getDiscountPolicyDetailId())
+                    .map(g -> g.getPlace().getPlaceId())
+                    .map(List::of)
+                    .orElse(List.of());
+        }
+    }
+}
+

--- a/src/main/java/com/unear/userservice/place/service/impl/PlaceServiceImpl.java
+++ b/src/main/java/com/unear/userservice/place/service/impl/PlaceServiceImpl.java
@@ -1,10 +1,8 @@
 package com.unear.userservice.place.service.impl;
 
-import com.unear.userservice.benefit.entity.FranchiseDiscountPolicy;
 import com.unear.userservice.benefit.entity.GeneralDiscountPolicy;
 import com.unear.userservice.benefit.repository.FranchiseDiscountPolicyRepository;
 import com.unear.userservice.benefit.repository.GeneralDiscountPolicyRepository;
-import com.unear.userservice.common.enums.DiscountPolicy;
 import com.unear.userservice.common.enums.PlaceType;
 import com.unear.userservice.common.exception.exception.PlaceNotFoundException;
 import com.unear.userservice.common.exception.exception.UserNotFoundException;
@@ -26,17 +24,14 @@ import com.unear.userservice.user.entity.User;
 import com.unear.userservice.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.text.NumberFormat;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static com.unear.userservice.common.enums.DiscountPolicy.*;
 
 @Service
 @AllArgsConstructor
@@ -97,7 +92,10 @@ public class PlaceServiceImpl implements PlaceService {
         List<Place> singlePlaceList = List.of(place);
         List<Franchise> franchises = place.getFranchise() != null ? List.of(place.getFranchise()) : List.of();
 
-        List<UserCoupon> userCoupons = userCouponRepository.findByUser_UserId(userId);
+        List<UserCoupon> userCoupons = userId != null
+                ? userCouponRepository.findByUser_UserId(userId)
+                : List.of();
+
         Map<Long, Long> templateToUserCouponId = userCoupons.stream()
                 .filter(uc -> uc.getCouponTemplate() != null)
                 .collect(Collectors.toMap(
@@ -105,9 +103,11 @@ public class PlaceServiceImpl implements PlaceService {
                         UserCoupon::getUserCouponId
                 ));
 
-        String membershipCode = userRepository.findById(userId)
+        String membershipCode = userId != null
+                ? userRepository.findById(userId)
                 .map(User::getMembershipCode)
-                .orElse(null);
+                .orElse(null)
+                : null;
 
         List<CouponTemplate> templates = couponTemplateRepository.findByPlacesAndMembership(
                 singlePlaceList, franchises, membershipCode);

--- a/src/main/java/com/unear/userservice/place/service/impl/PlaceServiceImpl.java
+++ b/src/main/java/com/unear/userservice/place/service/impl/PlaceServiceImpl.java
@@ -4,6 +4,7 @@ import com.unear.userservice.benefit.entity.FranchiseDiscountPolicy;
 import com.unear.userservice.benefit.entity.GeneralDiscountPolicy;
 import com.unear.userservice.benefit.repository.FranchiseDiscountPolicyRepository;
 import com.unear.userservice.benefit.repository.GeneralDiscountPolicyRepository;
+import com.unear.userservice.common.enums.DiscountPolicy;
 import com.unear.userservice.common.enums.PlaceType;
 import com.unear.userservice.common.exception.exception.PlaceNotFoundException;
 import com.unear.userservice.common.exception.exception.UserNotFoundException;
@@ -25,12 +26,17 @@ import com.unear.userservice.user.entity.User;
 import com.unear.userservice.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.text.NumberFormat;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.unear.userservice.common.enums.DiscountPolicy.*;
 
 @Service
 @AllArgsConstructor
@@ -43,6 +49,7 @@ public class PlaceServiceImpl implements PlaceService {
     private final CouponTemplateRepository couponTemplateRepository;
     private final FranchiseDiscountPolicyRepository franchiseDiscountPolicyRepository;
     private final GeneralDiscountPolicyRepository generalDiscountPolicyRepository;
+    private final BenefitDescriptionResolver benefitDescriptionResolver;
 
     @Override
     public List<PlaceRenderResponseDto> getFilteredPlaces(PlaceRequestDto requestDto, Long userId) {
@@ -69,7 +76,8 @@ public class PlaceServiceImpl implements PlaceService {
 
 
     @Override
-    public PlaceResponseDto getPlaceDetail(Long placeId, Long userId, Double latitude, Double longitude) {
+    @org.springframework.transaction.annotation.Transactional(readOnly = true)
+    public NearbyPlaceWithCouponsDto getPlaceDetail(Long placeId, Long userId, Double latitude, Double longitude) {
         Place place = placeRepository.findById(placeId)
                 .orElseThrow(() -> new PlaceNotFoundException("해당 장소가 존재하지 않습니다."));
 
@@ -82,12 +90,98 @@ public class PlaceServiceImpl implements PlaceService {
         if (latitude != null && longitude != null && place.getLocation() != null) {
             Double distanceMeters = placeRepository.calculateDistance(placeId, latitude, longitude);
             if (distanceMeters != null) {
-                distanceKm = Math.round( distanceMeters / 100.0) / 10.0;
+                distanceKm = Math.round(distanceMeters / 100.0) / 10.0;
             }
         }
 
-        return PlaceResponseDto.from(place, isFavorite, distanceKm);
+        List<Place> singlePlaceList = List.of(place);
+        List<Franchise> franchises = place.getFranchise() != null ? List.of(place.getFranchise()) : List.of();
+
+        List<UserCoupon> userCoupons = userCouponRepository.findByUser_UserId(userId);
+        Map<Long, Long> templateToUserCouponId = userCoupons.stream()
+                .filter(uc -> uc.getCouponTemplate() != null)
+                .collect(Collectors.toMap(
+                        uc -> uc.getCouponTemplate().getCouponTemplateId(),
+                        UserCoupon::getUserCouponId
+                ));
+
+        String membershipCode = userRepository.findById(userId)
+                .map(User::getMembershipCode)
+                .orElse(null);
+
+        List<CouponTemplate> templates = couponTemplateRepository.findByPlacesAndMembership(
+                singlePlaceList, franchises, membershipCode);
+
+        List<CouponResponseDto> coupons = templates.stream()
+                .filter(ct -> benefitDescriptionResolver.resolvePlaceIdFromTemplateList(ct, singlePlaceList).contains(placeId))
+                .map(ct -> {
+                    Long templateId = ct.getCouponTemplateId();
+                    boolean isDownloaded = templateToUserCouponId.containsKey(templateId);
+                    Long userCouponId = templateToUserCouponId.get(templateId);
+                    return CouponResponseDto.from(ct, null, isDownloaded, userCouponId);
+                })
+                .toList();
+
+
+        DiscountPolicyRef policyRef = templates.stream()
+                .filter(ct -> benefitDescriptionResolver.resolvePlaceIdFromTemplateList(ct, singlePlaceList).contains(placeId))
+                .map(ct -> {
+                    PlaceType markerType = PlaceType.fromCode(ct.getMarkerCode());
+                    if (markerType.isFranchise()) {
+                        Long franchiseId = (ct.getDiscountPolicyDetailId() != null)
+                                ? franchiseDiscountPolicyRepository.findById(ct.getDiscountPolicyDetailId())
+                                .map(f -> f.getFranchise().getFranchiseId())
+                                .orElse(null)
+                                : place.getFranchise() != null ? place.getFranchise().getFranchiseId() : null;
+                        return new DiscountPolicyRef(placeId, null, franchiseId);
+                    } else {
+                        return new DiscountPolicyRef(placeId, ct.getDiscountPolicyDetailId(), null);
+                    }
+                })
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElse(null);
+
+        if ((policyRef == null || policyRef.franchiseId() == null) && place.getFranchise() != null) {
+            policyRef = new DiscountPolicyRef(place.getPlaceId(), null, place.getFranchise().getFranchiseId());
+        }
+
+        List<GeneralDiscountPolicy> generalPolicies = generalDiscountPolicyRepository.findByPlaceIn(singlePlaceList);
+        for (GeneralDiscountPolicy policy : generalPolicies) {
+            Long pid = policy.getPlace().getPlaceId();
+            if (policyRef == null || policyRef.discountPolicyDetailId() == null) {
+                policyRef = new DiscountPolicyRef(pid, policy.getGeneralDiscountPolicyId(), null);
+            }
+        }
+
+        Long franchiseId = (policyRef != null && policyRef.franchiseId() != null)
+                ? policyRef.franchiseId()
+                : (place.getFranchise() != null ? place.getFranchise().getFranchiseId() : null);
+
+        String benefitDesc = benefitDescriptionResolver.resolveBenefitDesc(policyRef, membershipCode);
+
+        return NearbyPlaceWithCouponsDto.builder()
+                .placeId(place.getPlaceId())
+                .name(place.getPlaceName())
+                .address(place.getAddress())
+                .categoryCode(place.getCategoryCode())
+                .distanceKm(distanceKm)
+                .latitude(place.getLatitude())
+                .longitude(place.getLongitude())
+                .startTime(place.getStartTime())
+                .endTime(place.getEndTime())
+                .tel(place.getTel())
+                .markerCode(place.getMarkerCode())
+                .eventTypeCode(place.getEventTypeCode())
+                .favorite(isFavorite)
+                .discountPolicyDetailId(policyRef != null ? policyRef.discountPolicyDetailId() : null)
+                .franchiseId(franchiseId)
+                .coupons(coupons)
+                .benefitDesc(benefitDesc)
+                .build();
     }
+
+
 
 
 
@@ -172,28 +266,85 @@ public class PlaceServiceImpl implements PlaceService {
                 places, franchises, membershipCode);
 
         Map<Long, List<CouponResponseDto>> couponMap = templates.stream()
-                .map(ct -> {
+                .flatMap(ct -> {
                     Long templateId = ct.getCouponTemplateId();
                     boolean isDownloaded = templateToUserCouponId.containsKey(templateId);
                     Long userCouponId = templateToUserCouponId.get(templateId);
-                    Long resolvedPlaceId = resolvePlaceIdFromTemplate(ct, places);
-                    if (resolvedPlaceId == null) return null;
+                    List<Long> resolvedPlaceIds = benefitDescriptionResolver.resolvePlaceIdFromTemplateList(ct, places);
+                    if (resolvedPlaceIds == null || resolvedPlaceIds.isEmpty()) return Stream.empty();
 
-                    return Map.entry(
-                            resolvedPlaceId,
-                            CouponResponseDto.from(ct, null, isDownloaded, userCouponId)
-                    );
+                    return resolvedPlaceIds.stream()
+                            .map(placeId -> Map.entry(
+                                    placeId,
+                                    CouponResponseDto.from(ct, null, isDownloaded, userCouponId)
+                            ));
                 })
-                .filter(Objects::nonNull)
                 .collect(Collectors.groupingBy(
                         Map.Entry::getKey,
                         Collectors.mapping(Map.Entry::getValue, Collectors.toList())
                 ));
 
+
+
+
+        Map<Long, DiscountPolicyRef> policyRefMap = templates.stream()
+                .flatMap(ct -> {
+                    List<Long> resolvedPlaceIds = benefitDescriptionResolver.resolvePlaceIdFromTemplateList(ct, places);
+                    if (resolvedPlaceIds == null || resolvedPlaceIds.isEmpty()) return Stream.empty();
+
+                    PlaceType markerType = PlaceType.fromCode(ct.getMarkerCode());
+                    return resolvedPlaceIds.stream().map(placeId -> {
+                        if (markerType.isFranchise()) {
+                            Long franchiseId = null;
+                            Long policyId = ct.getDiscountPolicyDetailId();
+
+                            if (policyId != null) {
+                                franchiseId = franchiseDiscountPolicyRepository.findById(policyId)
+                                        .map(f -> f.getFranchise().getFranchiseId())
+                                        .orElse(null);
+                            } else {
+                                franchiseId = placeMap.get(placeId).getFranchise().getFranchiseId();
+                            }
+
+                            return Map.entry(placeId, new DiscountPolicyRef(placeId, null, franchiseId));
+                        } else {
+                            return Map.entry(placeId, new DiscountPolicyRef(placeId, ct.getDiscountPolicyDetailId(), null));
+                        }
+                    });
+                })
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (a, b) -> a));
+
+
+
+        List<GeneralDiscountPolicy> generalPolicies = generalDiscountPolicyRepository.findByPlaceIn(places);
+        for (GeneralDiscountPolicy policy : generalPolicies) {
+            Long placeId = policy.getPlace().getPlaceId();
+            if (!policyRefMap.containsKey(placeId)) {
+                policyRefMap.put(placeId, new DiscountPolicyRef(placeId, policy.getGeneralDiscountPolicyId(), null));
+            }
+        }
+
+        for (Place place : places) {
+            if (!policyRefMap.containsKey(place.getPlaceId()) && place.getFranchise() != null) {
+                policyRefMap.put(place.getPlaceId(), new DiscountPolicyRef(
+                        place.getPlaceId(), null, place.getFranchise().getFranchiseId()));
+            }
+        }
+
         return projections.stream()
                 .map(p -> {
+
                     Place place = placeMap.get(p.getPlaceId());
                     if (place == null) return null;
+
+                    boolean isFavorite = favoritePlaceRepository.existsByUser_UserIdAndPlace_PlaceIdAndIsFavoritedTrue(userId, place.getPlaceId());
+                    DiscountPolicyRef policyRef = policyRefMap.get(place.getPlaceId());
+
+                    String benefitDesc = benefitDescriptionResolver.resolveBenefitDesc(policyRef, membershipCode);
+
+                    Long franchiseId = (policyRef != null && policyRef.franchiseId() != null)
+                            ? policyRef.franchiseId()
+                            : (place.getFranchise() != null ? place.getFranchise().getFranchiseId() : null);
 
                     return NearbyPlaceWithCouponsDto.builder()
                             .placeId(place.getPlaceId())
@@ -201,34 +352,30 @@ public class PlaceServiceImpl implements PlaceService {
                             .address(place.getAddress())
                             .categoryCode(place.getCategoryCode())
                             .distanceKm(Math.round(p.getDistance() / 100.0) / 10.0)
+                            .latitude(place.getLatitude())
+                            .longitude(place.getLongitude())
+                            .startTime(place.getStartTime())
+                            .endTime(place.getEndTime())
+                            .tel(place.getTel())
+                            .markerCode(place.getMarkerCode())
+                            .eventTypeCode(place.getEventTypeCode())
+                            .favorite(isFavorite)
+                            .discountPolicyDetailId(policyRef != null ? policyRef.discountPolicyDetailId() : null)
+                            .franchiseId(franchiseId)
                             .coupons(couponMap.getOrDefault(place.getPlaceId(), List.of()))
+                            .benefitDesc(benefitDesc)
                             .build();
+
                 })
                 .filter(Objects::nonNull)
                 .toList();
     }
 
-
-
-    private Long resolvePlaceIdFromTemplate(CouponTemplate ct, List<Place> places) {
-        PlaceType markerType = PlaceType.fromCode(ct.getMarkerCode());
-        if (markerType.isFranchise()) {
-            Long franchiseId = franchiseDiscountPolicyRepository.findById(ct.getDiscountPolicyDetailId())
-                    .map(FranchiseDiscountPolicy::getFranchise)
-                    .map(Franchise::getFranchiseId)
-                    .orElse(null);
-            return places.stream()
-                    .filter(p -> p.getFranchise() != null && p.getFranchise().getFranchiseId().equals(franchiseId))
-                    .map(Place::getPlaceId)
-                    .findFirst()
-                    .orElse(null);
-        } else {
-            return generalDiscountPolicyRepository.findById(ct.getDiscountPolicyDetailId())
-                    .map(GeneralDiscountPolicy::getPlace)
-                    .map(Place::getPlaceId)
-                    .orElse(null);
-        }
-    }
+    public record DiscountPolicyRef(
+            Long placeId,
+            Long discountPolicyDetailId,
+            Long franchiseId
+    ) {}
 
 
 }

--- a/src/main/java/com/unear/userservice/place/service/impl/PlaceServiceImpl.java
+++ b/src/main/java/com/unear/userservice/place/service/impl/PlaceServiceImpl.java
@@ -334,13 +334,18 @@ public class PlaceServiceImpl implements PlaceService {
             }
         }
 
+        Set<Long> favoriteIds = userId != null
+                ? favoritePlaceRepository.findPlaceIdsByUserId(userId)
+                : Set.of();
+
         return projections.stream()
                 .map(p -> {
 
                     Place place = placeMap.get(p.getPlaceId());
                     if (place == null) return null;
 
-                    boolean isFavorite = favoritePlaceRepository.existsByUser_UserIdAndPlace_PlaceIdAndIsFavoritedTrue(userId, place.getPlaceId());
+                    boolean isFavorite = favoriteIds.contains(place.getPlaceId());
+
                     DiscountPolicyRef policyRef = policyRefMap.get(place.getPlaceId());
 
                     String benefitDesc = benefitDescriptionResolver.resolveBenefitDesc(policyRef, membershipCode);

--- a/src/main/java/com/unear/userservice/place/service/impl/PlaceServiceImpl.java
+++ b/src/main/java/com/unear/userservice/place/service/impl/PlaceServiceImpl.java
@@ -303,7 +303,10 @@ public class PlaceServiceImpl implements PlaceService {
                                         .map(f -> f.getFranchise().getFranchiseId())
                                         .orElse(null);
                             } else {
-                                franchiseId = placeMap.get(placeId).getFranchise().getFranchiseId();
+                                Place place = placeMap.get(placeId);
+                                franchiseId = (place != null && place.getFranchise() != null)
+                                        ? place.getFranchise().getFranchiseId()
+                                        : null;
                             }
 
                             return Map.entry(placeId, new DiscountPolicyRef(placeId, null, franchiseId));

--- a/src/main/java/com/unear/userservice/stamp/domain/StampCollection.java
+++ b/src/main/java/com/unear/userservice/stamp/domain/StampCollection.java
@@ -5,6 +5,7 @@ import com.unear.userservice.stamp.entity.Stamp;
 import com.unear.userservice.common.enums.EventType;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class StampCollection {


### PR DESCRIPTION
## PR 목적

- place_id로 장소 상세조회 반환값 수정
- 주변 장소 조회 반환값 수정
- 두 api 모두 benefitDesc 필드 추가되어 반환되도록 수정


## 변경 사항

- BenefitDescriptionResolver 추가 ( 할인정책 문자열로 매핑  )
- 장소 조회시 , 위도/경도/운영시간/즐겨찾기 여부/마커정보/전화번호 정보 추가
- 장소마다 benefitDesc , 쿠폰 리스트 함께 조회되도록 로직 수정

## 주요 구현 내용

- 할인정책 id 네이밍 수정
- getMyCoupons -> 팝업인경우, NPE 예외처리 추가
- PlcaeController -> getPlace , getNearbyPlaces 반환 dto NearbyPlaceWithCouponsDto로 통일
- NearbyPlaceWithCouponsDto 필드 추가
- PlaceServiceImpl -> getPlaceDetail , getNearbyPlacesWithCoupons 로직 수정
- 각 장소와 관련된 정보 한번에 조회되도록 수정 ( 혜택정보, 쿠폰 정보 )
- DiscountPolicy Enum 비교 메서드 추가
- CouponTemplateRepository -> findByPlacesAndMembership 멤버십 등급 ALL 인 경우도 조회되도록 수정
- BenefitDescriptionResolver 추가 ( 할인정책 매핑해주는 resolver 분리)

## 테스트 및 동작 화면 (필요 시 첨부)

- place_id로 장소 상세 조회
<img width="497" height="656" alt="스크린샷 2025-07-25 오후 2 31 36" src="https://github.com/user-attachments/assets/dacce0c8-76e5-40a4-9006-0a20d620e9ef" />

- 사용자 기준으로 가까운장소 및 쿠폰 템플릿 조회
<img width="659" height="1001" alt="스크린샷 2025-07-25 오후 2 32 21" src="https://github.com/user-attachments/assets/def3175c-619b-4a13-80cf-aca57d77e3ae" />
<img width="642" height="905" alt="스크린샷 2025-07-25 오후 2 32 35" src="https://github.com/user-attachments/assets/f2de441a-d397-49d5-b230-734fe9519a61" />


## 리뷰 시 중점적으로 봐야 할 부분

- PlaceServiceImpl -> getPlaceDetail , getNearbyPlacesWithCoupons 로직이 올바른지


## 병합 전 체크리스트

- [v] 로컬 테스트 완료
- [v] Postman 테스트 포함
- [ ] 코드래빗 리뷰 검토
