### PR TITLE
[Wl7-363] UserActionLogProducer 추가

### DIFF
--- a/src/main/java/com/unear/userservice/benefit/controller/DiscountPolicyController.java
+++ b/src/main/java/com/unear/userservice/benefit/controller/DiscountPolicyController.java
@@ -8,11 +8,13 @@ import com.unear.userservice.benefit.dto.response.FranchiseDiscountPolicyRespons
 import com.unear.userservice.benefit.service.DiscountPolicyService;
 import com.unear.userservice.common.docs.benefit.BenefitApiDocs;
 import com.unear.userservice.common.response.ApiResponse;
+import com.unear.userservice.common.security.CustomUser;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -26,27 +28,33 @@ public class DiscountPolicyController {
     @BenefitApiDocs.GetGeneralDiscountPolicyDetail
     @GetMapping("/{discount_policy_detail_id}")
     public ResponseEntity<ApiResponse<GeneralDiscountPolicyDetailResponseDto>> getDiscountPolicyDetail(
-            @PathVariable("discount_policy_detail_id") Long discountPolicyDetailId
+            @PathVariable("discount_policy_detail_id") Long discountPolicyDetailId,
+            @AuthenticationPrincipal CustomUser user
     ) {
-        GeneralDiscountPolicyDetailResponseDto response = discountPolicyService.getDiscountPolicyDetail(discountPolicyDetailId);
+        Long userId = (user != null && user.getUser() != null) ? user.getUser().getUserId() : null;
+        GeneralDiscountPolicyDetailResponseDto response = discountPolicyService.getDiscountPolicyDetail(userId, discountPolicyDetailId);
         return ResponseEntity.ok(ApiResponse.success("혜택 상세 조회 성공", response));
     }
 
     @BenefitApiDocs.GetFranchiseDiscountPolicyList
     @GetMapping("/franchise")
     public ResponseEntity<ApiResponse<Page<FranchiseDiscountPolicyResponseDto>>> getFranchiseDiscountPolicies(
-            @ParameterObject @ModelAttribute FranchiseDiscountPolicyRequestDto requestDto
+            @ParameterObject @ModelAttribute FranchiseDiscountPolicyRequestDto requestDto,
+            @AuthenticationPrincipal CustomUser user
     ) {
-        Page<FranchiseDiscountPolicyResponseDto> response = discountPolicyService.getFranchiseDiscountPolicies(requestDto);
+        Long userId = (user != null && user.getUser() != null) ? user.getUser().getUserId() : null;
+        Page<FranchiseDiscountPolicyResponseDto> response = discountPolicyService.getFranchiseDiscountPolicies(userId, requestDto);
         return ResponseEntity.ok(ApiResponse.success("프랜차이즈 혜택 리스트 조회 성공", response));
     }
 
     @BenefitApiDocs.GetFranchiseDiscountPolicyDetail
     @GetMapping("/franchise/{franchise_id}")
     public ResponseEntity<ApiResponse<FranchiseDiscountPolicyDetailResponseDto>> getFranchiseDiscountPolicyDetail(
-            @PathVariable("franchise_id") Long franchiseId
+            @PathVariable("franchise_id") Long franchiseId,
+            @AuthenticationPrincipal CustomUser user
     ) {
-        FranchiseDiscountPolicyDetailResponseDto response = discountPolicyService.getFranchiseDiscountPolicyDetail(franchiseId);
+        Long userId = (user != null && user.getUser() != null) ? user.getUser().getUserId() : null;
+        FranchiseDiscountPolicyDetailResponseDto response = discountPolicyService.getFranchiseDiscountPolicyDetail(userId, franchiseId);
         return ResponseEntity.ok(ApiResponse.success("프랜차이즈 혜택 상세 조회 성공", response));
     }
 

--- a/src/main/java/com/unear/userservice/benefit/repository/FranchiseDiscountPolicyRepository.java
+++ b/src/main/java/com/unear/userservice/benefit/repository/FranchiseDiscountPolicyRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 
 public interface FranchiseDiscountPolicyRepository extends JpaRepository<FranchiseDiscountPolicy, Long> {
@@ -14,4 +15,8 @@ public interface FranchiseDiscountPolicyRepository extends JpaRepository<Franchi
     List<Long> findPolicyIdsByFranchiseId(@Param("franchiseId") Long franchiseId);
 
     List<FranchiseDiscountPolicy> findByFranchise_FranchiseId(Long franchiseId);
+
+    @Query("SELECT p FROM FranchiseDiscountPolicy p JOIN FETCH p.franchise WHERE p.franchiseDiscountPolicyId = :id")
+    Optional<FranchiseDiscountPolicy> findWithFranchiseById(@Param("id") Long id);
+
 }

--- a/src/main/java/com/unear/userservice/benefit/service/DiscountPolicyService.java
+++ b/src/main/java/com/unear/userservice/benefit/service/DiscountPolicyService.java
@@ -8,8 +8,8 @@ import org.springframework.data.domain.Page;
 
 public interface DiscountPolicyService {
 
-    GeneralDiscountPolicyDetailResponseDto getDiscountPolicyDetail(Long discountPolicyDetailId);
-    Page<FranchiseDiscountPolicyResponseDto> getFranchiseDiscountPolicies(FranchiseDiscountPolicyRequestDto requestDto);
-    FranchiseDiscountPolicyDetailResponseDto getFranchiseDiscountPolicyDetail(Long franchiseId);
+    GeneralDiscountPolicyDetailResponseDto getDiscountPolicyDetail(Long userId, Long discountPolicyDetailId);
+    Page<FranchiseDiscountPolicyResponseDto> getFranchiseDiscountPolicies(Long userId, FranchiseDiscountPolicyRequestDto requestDto);
+    FranchiseDiscountPolicyDetailResponseDto getFranchiseDiscountPolicyDetail(Long userId, Long franchiseId);
 
 }

--- a/src/main/java/com/unear/userservice/benefit/service/impl/DiscountPolicyServiceImpl.java
+++ b/src/main/java/com/unear/userservice/benefit/service/impl/DiscountPolicyServiceImpl.java
@@ -8,7 +8,9 @@ import com.unear.userservice.benefit.entity.GeneralDiscountPolicy;
 import com.unear.userservice.benefit.repository.GeneralDiscountPolicyRepository;
 import com.unear.userservice.benefit.repository.FranchiseRepository;
 import com.unear.userservice.benefit.service.DiscountPolicyService;
+import com.unear.userservice.common.enums.UserActionType;
 import com.unear.userservice.common.exception.exception.BenefitNotFoundException;
+import com.unear.userservice.common.redis.producer.UserActionLogProducer;
 import com.unear.userservice.place.entity.Franchise;
 import jakarta.persistence.criteria.Predicate;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +30,7 @@ public class DiscountPolicyServiceImpl implements DiscountPolicyService {
 
     private final GeneralDiscountPolicyRepository generalDiscountPolicyRepository;
     private final FranchiseRepository franchiseRepository;
+    private final UserActionLogProducer userActionLogProducer;
 
     @Override
     public GeneralDiscountPolicyDetailResponseDto getDiscountPolicyDetail(Long userId, Long discountPolicyDetailId) {
@@ -62,6 +65,15 @@ public class DiscountPolicyServiceImpl implements DiscountPolicyService {
     public FranchiseDiscountPolicyDetailResponseDto getFranchiseDiscountPolicyDetail(Long userId, Long franchiseId) {
         Franchise franchise = franchiseRepository.findWithPoliciesByFranchiseId(franchiseId)
                 .orElseThrow(() -> new BenefitNotFoundException("프랜차이즈 혜택을 찾을 수 없습니다."));
+
+
+        userActionLogProducer.sendLog(
+                String.valueOf(userId),
+                UserActionType.BENEFIT_DETAIL.name(),
+                "franchiseName:" + franchise.getName()
+        );
+
+
         return FranchiseDiscountPolicyDetailResponseDto.from(franchise);
     }
 

--- a/src/main/java/com/unear/userservice/benefit/service/impl/DiscountPolicyServiceImpl.java
+++ b/src/main/java/com/unear/userservice/benefit/service/impl/DiscountPolicyServiceImpl.java
@@ -57,6 +57,24 @@ public class DiscountPolicyServiceImpl implements DiscountPolicyService {
             return cb.and(predicates.toArray(new Predicate[0]));
         };
 
+        if (requestDto.getFranchiseName() != null) {
+            userActionLogProducer.sendLog(
+                    String.valueOf(userId),
+                    UserActionType.BENEFIT_KEYWORD.name(),
+                    "benefitPage",
+                    "keyword:" + requestDto.getFranchiseName()
+            );
+        }
+        if (requestDto.getCategoryCode() != null) {
+            userActionLogProducer.sendLog(
+                    String.valueOf(userId),
+                    UserActionType.BENEFIT_CATEGORY.name(),
+                    "benefitPage",
+                    "category:" + requestDto.getCategoryCode()
+            );
+        }
+
+
         return franchiseRepository.findAll(spec, pageable)
                 .map(FranchiseDiscountPolicyResponseDto::from);
     }
@@ -70,6 +88,7 @@ public class DiscountPolicyServiceImpl implements DiscountPolicyService {
         userActionLogProducer.sendLog(
                 String.valueOf(userId),
                 UserActionType.BENEFIT_DETAIL.name(),
+                "benefitPage",
                 "franchiseName:" + franchise.getName()
         );
 

--- a/src/main/java/com/unear/userservice/benefit/service/impl/DiscountPolicyServiceImpl.java
+++ b/src/main/java/com/unear/userservice/benefit/service/impl/DiscountPolicyServiceImpl.java
@@ -30,7 +30,7 @@ public class DiscountPolicyServiceImpl implements DiscountPolicyService {
     private final FranchiseRepository franchiseRepository;
 
     @Override
-    public GeneralDiscountPolicyDetailResponseDto getDiscountPolicyDetail(Long discountPolicyDetailId) {
+    public GeneralDiscountPolicyDetailResponseDto getDiscountPolicyDetail(Long userId, Long discountPolicyDetailId) {
         GeneralDiscountPolicy detail = generalDiscountPolicyRepository.findWithPlaceAndFranchiseById(discountPolicyDetailId)
                 .orElseThrow(() -> new BenefitNotFoundException("해당 혜택 정보를 찾을 수 없습니다."));
 
@@ -38,7 +38,7 @@ public class DiscountPolicyServiceImpl implements DiscountPolicyService {
     }
 
     @Override
-    public Page<FranchiseDiscountPolicyResponseDto> getFranchiseDiscountPolicies(FranchiseDiscountPolicyRequestDto requestDto) {
+    public Page<FranchiseDiscountPolicyResponseDto> getFranchiseDiscountPolicies(Long userId, FranchiseDiscountPolicyRequestDto requestDto) {
         Pageable pageable = PageRequest.of(requestDto.getPage(), requestDto.getSize(), Sort.by("franchiseId").ascending());
 
         Specification<Franchise> spec = (root, query, cb) -> {
@@ -59,7 +59,7 @@ public class DiscountPolicyServiceImpl implements DiscountPolicyService {
     }
 
     @Override
-    public FranchiseDiscountPolicyDetailResponseDto getFranchiseDiscountPolicyDetail(Long franchiseId) {
+    public FranchiseDiscountPolicyDetailResponseDto getFranchiseDiscountPolicyDetail(Long userId, Long franchiseId) {
         Franchise franchise = franchiseRepository.findWithPoliciesByFranchiseId(franchiseId)
                 .orElseThrow(() -> new BenefitNotFoundException("프랜차이즈 혜택을 찾을 수 없습니다."));
         return FranchiseDiscountPolicyDetailResponseDto.from(franchise);

--- a/src/main/java/com/unear/userservice/benefit/service/impl/DiscountPolicyServiceImpl.java
+++ b/src/main/java/com/unear/userservice/benefit/service/impl/DiscountPolicyServiceImpl.java
@@ -58,21 +58,13 @@ public class DiscountPolicyServiceImpl implements DiscountPolicyService {
         };
 
         if (requestDto.getFranchiseName() != null) {
-            userActionLogProducer.sendLog(
-                    String.valueOf(userId),
-                    UserActionType.BENEFIT_KEYWORD.name(),
-                    "benefitPage",
-                    "keyword:" + requestDto.getFranchiseName()
-            );
+            userActionLogProducer.logUserAction(userId, UserActionType.BENEFIT_KEYWORD, "benefitPage", "keyword:" + requestDto.getFranchiseName());
         }
+
         if (requestDto.getCategoryCode() != null) {
-            userActionLogProducer.sendLog(
-                    String.valueOf(userId),
-                    UserActionType.BENEFIT_CATEGORY.name(),
-                    "benefitPage",
-                    "category:" + requestDto.getCategoryCode()
-            );
+            userActionLogProducer.logUserAction(userId, UserActionType.BENEFIT_CATEGORY, "benefitPage", "category:" + requestDto.getCategoryCode());
         }
+
 
 
         return franchiseRepository.findAll(spec, pageable)
@@ -84,14 +76,7 @@ public class DiscountPolicyServiceImpl implements DiscountPolicyService {
         Franchise franchise = franchiseRepository.findWithPoliciesByFranchiseId(franchiseId)
                 .orElseThrow(() -> new BenefitNotFoundException("프랜차이즈 혜택을 찾을 수 없습니다."));
 
-
-        userActionLogProducer.sendLog(
-                String.valueOf(userId),
-                UserActionType.BENEFIT_DETAIL.name(),
-                "benefitPage",
-                "franchiseName:" + franchise.getName()
-        );
-
+        userActionLogProducer.logUserAction(userId, UserActionType.BENEFIT_DETAIL, "benefitPage", "franchiseName:" + franchise.getName());
 
         return FranchiseDiscountPolicyDetailResponseDto.from(franchise);
     }

--- a/src/main/java/com/unear/userservice/common/enums/UserActionType.java
+++ b/src/main/java/com/unear/userservice/common/enums/UserActionType.java
@@ -17,7 +17,7 @@ public enum UserActionType {
     DOWNLOAD_FCFS_COUPON("선착순 쿠폰 다운로드"),
     ROULETTE_SPIN("룰렛 돌리기"),
     STAMP_CHECK_IN("스탬프 출석"),
-    BENEFIT_USAGE("혜택 사용");
+    POS_USAGE("결제시 사용된 혜택");
 
     private final String description;
 

--- a/src/main/java/com/unear/userservice/common/enums/UserActionType.java
+++ b/src/main/java/com/unear/userservice/common/enums/UserActionType.java
@@ -1,0 +1,28 @@
+package com.unear.userservice.common.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum UserActionType {
+
+    BENEFIT_KEYWORD("키워드 검색"),
+    BENEFIT_CATEGORY("카테고리 클릭"),
+    BENEFIT_DETAIL("혜택 상세 진입"),
+    PLACE_FILTER("필터 적용"),
+    PLACE_KEYWORD("장소 키워드 검색"),
+    VIEW_PLACE_DETAIL("장소 상세 진입"),
+    FAVORITE_ON("즐겨찾기 등록"),
+    FAVORITE_OFF("즐겨찾기 해제"),
+    DOWNLOAD_COUPON("일반 쿠폰 다운로드"),
+    DOWNLOAD_FCFS_COUPON("선착순 쿠폰 다운로드"),
+    ROULETTE_SPIN("룰렛 돌리기"),
+    STAMP_CHECK_IN("스탬프 출석"),
+    BENEFIT_USAGE("혜택 사용");
+
+    private final String description;
+
+    UserActionType(String description) {
+        this.description = description;
+    }
+
+}

--- a/src/main/java/com/unear/userservice/common/redis/producer/UserActionLogProducer.java
+++ b/src/main/java/com/unear/userservice/common/redis/producer/UserActionLogProducer.java
@@ -1,0 +1,32 @@
+package com.unear.userservice.common.redis.producer;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class UserActionLogProducer {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    // RedisStream 키
+    private static final String STREAM_KEY = "stream:user_action_logs";
+
+    // 사용자 행동로그를 RedisStream에 기록
+    public void sendLog(String userId, String actionType, String metadata) {
+        Map<String, String> data = new HashMap<>();
+        data.put("userId", userId); // 사용자 id
+        data.put("actionType", actionType); // 행동 유형
+        data.put("metadata", metadata); // 부가 정보
+        data.put("timestamp", String.valueOf(System.currentTimeMillis())); // 시간
+
+        // XADD
+        redisTemplate.opsForStream()
+                .add(MapRecord.create(STREAM_KEY, data));
+    }
+}

--- a/src/main/java/com/unear/userservice/common/redis/producer/UserActionLogProducer.java
+++ b/src/main/java/com/unear/userservice/common/redis/producer/UserActionLogProducer.java
@@ -21,7 +21,7 @@ public class UserActionLogProducer {
     private static final String STREAM_KEY = "stream:user_action_logs";
 
     @Async
-    public void sendLog(String userId, String actionType, String screen , String metadata) {
+    public void sendLog(String userId, String actionType, String screen ,String metadata) {
         try {
             Map<String, String> data = new HashMap<>();
             data.put("userId", userId);

--- a/src/main/java/com/unear/userservice/common/redis/producer/UserActionLogProducer.java
+++ b/src/main/java/com/unear/userservice/common/redis/producer/UserActionLogProducer.java
@@ -1,5 +1,6 @@
 package com.unear.userservice.common.redis.producer;
 
+import com.unear.userservice.common.enums.UserActionType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.connection.stream.MapRecord;
@@ -32,4 +33,20 @@ public class UserActionLogProducer {
         redisTemplate.opsForStream()
                 .add(MapRecord.create(STREAM_KEY, data));
     }
+
+    public void logUserAction(Long userId, UserActionType actionType, String screen, String metadata) {
+        if (userId == null) return;
+
+        try {
+            sendLog(
+                    userId.toString(),
+                    actionType.name(),
+                    screen,
+                    metadata
+            );
+        } catch (Exception e) {
+            log.warn("{} 로그 전송 실패", actionType.name(), e);
+        }
+    }
+
 }

--- a/src/main/java/com/unear/userservice/common/redis/producer/UserActionLogProducer.java
+++ b/src/main/java/com/unear/userservice/common/redis/producer/UserActionLogProducer.java
@@ -22,21 +22,24 @@ public class UserActionLogProducer {
 
     @Async
     public void sendLog(String userId, String actionType, String screen , String metadata) {
-        Map<String, String> data = new HashMap<>();
-        data.put("userId", userId);
-        data.put("actionType", actionType);
-        data.put("screen", screen);
-        data.put("metadata", metadata);
-        data.put("timestamp", String.valueOf(System.currentTimeMillis()));
-        log.info("[로그 전송] userId={}, actionType={}, screen={}, metadata={}", userId, actionType, screen, metadata);
+        try {
+            Map<String, String> data = new HashMap<>();
+            data.put("userId", userId);
+            data.put("actionType", actionType);
+            data.put("screen", screen);
+            data.put("metadata", metadata);
+            data.put("timestamp", String.valueOf(System.currentTimeMillis()));
+            log.info("[로그 전송] userId={}, actionType={}, screen={}, metadata={}", userId, actionType, screen, metadata);
 
-        redisTemplate.opsForStream()
-                .add(MapRecord.create(STREAM_KEY, data));
+            redisTemplate.opsForStream()
+                    .add(MapRecord.create(STREAM_KEY, data));
+        } catch (Exception e) {
+            log.error("Redis 스트림 로그 전송 실패: userId={}, actionType={}", userId, actionType, e);
+            }
     }
 
     public void logUserAction(Long userId, UserActionType actionType, String screen, String metadata) {
         if (userId == null) return;
-
         try {
             sendLog(
                     userId.toString(),

--- a/src/main/java/com/unear/userservice/common/redis/producer/UserActionLogProducer.java
+++ b/src/main/java/com/unear/userservice/common/redis/producer/UserActionLogProducer.java
@@ -1,31 +1,34 @@
 package com.unear.userservice.common.redis.producer;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.connection.stream.MapRecord;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import java.util.HashMap;
 import java.util.Map;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserActionLogProducer {
 
     private final RedisTemplate<String, String> redisTemplate;
 
-    // RedisStream 키
     private static final String STREAM_KEY = "stream:user_action_logs";
 
-    // 사용자 행동로그를 RedisStream에 기록
-    public void sendLog(String userId, String actionType, String metadata) {
+    @Async
+    public void sendLog(String userId, String actionType, String screen , String metadata) {
         Map<String, String> data = new HashMap<>();
-        data.put("userId", userId); // 사용자 id
-        data.put("actionType", actionType); // 행동 유형
-        data.put("metadata", metadata); // 부가 정보
-        data.put("timestamp", String.valueOf(System.currentTimeMillis())); // 시간
+        data.put("userId", userId);
+        data.put("actionType", actionType);
+        data.put("screen", screen);
+        data.put("metadata", metadata);
+        data.put("timestamp", String.valueOf(System.currentTimeMillis()));
+        log.info("[로그 전송] userId={}, actionType={}, screen={}, metadata={}", userId, actionType, screen, metadata);
 
-        // XADD
         redisTemplate.opsForStream()
                 .add(MapRecord.create(STREAM_KEY, data));
     }

--- a/src/main/java/com/unear/userservice/coupon/dto/response/UserCouponDetailResponseDto.java
+++ b/src/main/java/com/unear/userservice/coupon/dto/response/UserCouponDetailResponseDto.java
@@ -10,6 +10,7 @@ import java.time.LocalDateTime;
 public class UserCouponDetailResponseDto {
 
     private Long userCouponId;
+    private String brandName;
     private String couponName;
     private String barcodeNumber;
     private String couponStatusCode;

--- a/src/main/java/com/unear/userservice/coupon/service/impl/CouponServiceImpl.java
+++ b/src/main/java/com/unear/userservice/coupon/service/impl/CouponServiceImpl.java
@@ -246,9 +246,10 @@ public class CouponServiceImpl implements CouponService {
 
         PlaceType placeType = PlaceType.fromCode(markerCode);
         if (placeType.isFranchise()) {
-            franchiseDiscountPolicyRepository.findById(template.getDiscountPolicyDetailId()).ifPresent(policy ->
+            franchiseDiscountPolicyRepository.findWithFranchiseById(template.getDiscountPolicyDetailId()).ifPresent(policy ->
                     builder
                             .discountCode(policy.getDiscountCode())
+                            .brandName(policy.getFranchise() != null ? policy.getFranchise().getName() : null)
                             .membershipCode(policy.getMembershipCode())
                             .fixedDiscount(policy.getFixedDiscount())
                             .discountPercent(policy.getDiscountPercent())

--- a/src/main/java/com/unear/userservice/coupon/service/impl/CouponServiceImpl.java
+++ b/src/main/java/com/unear/userservice/coupon/service/impl/CouponServiceImpl.java
@@ -4,11 +4,9 @@ import com.unear.userservice.benefit.entity.FranchiseDiscountPolicy;
 import com.unear.userservice.benefit.entity.GeneralDiscountPolicy;
 import com.unear.userservice.benefit.repository.FranchiseDiscountPolicyRepository;
 import com.unear.userservice.benefit.repository.GeneralDiscountPolicyRepository;
-import com.unear.userservice.common.enums.CouponStatus;
-import com.unear.userservice.common.enums.DiscountPolicy;
-import com.unear.userservice.common.enums.MembershipGrade;
-import com.unear.userservice.common.enums.PlaceType;
+import com.unear.userservice.common.enums.*;
 import com.unear.userservice.common.exception.exception.*;
+import com.unear.userservice.common.redis.producer.UserActionLogProducer;
 import com.unear.userservice.coupon.dto.response.CouponResponseDto;
 import com.unear.userservice.coupon.dto.response.UserCouponDetailResponseDto;
 import com.unear.userservice.coupon.dto.response.UserCouponListResponseDto;
@@ -41,6 +39,7 @@ public class CouponServiceImpl implements CouponService {
     private final CouponTemplateRepository couponTemplateRepository;
     private final UserCouponRepository userCouponRepository;
     private final UserRepository userRepository;
+    private final UserActionLogProducer userActionLogProducer;
 
     @Override
     @Transactional
@@ -117,6 +116,25 @@ public class CouponServiceImpl implements CouponService {
                 .barcodeNumber(generateUniqueBarcode())
                 .build();
 
+        if (template.getDiscountCode() != null) {
+            userActionLogProducer.sendLog(
+                    String.valueOf(userId),
+                    UserActionType.DOWNLOAD_COUPON.name(),
+                    "mapPage",
+                    "benefit:" + template.getDiscountCode()
+            );
+        }
+
+        if (template.getMembershipCode() != null) {
+            userActionLogProducer.sendLog(
+                    String.valueOf(userId),
+                    UserActionType.DOWNLOAD_COUPON.name(),
+                    "mapPage",
+                    "grade:" + template.getMembershipCode()
+            );
+        }
+
+
         try {
             userCouponRepository.save(userCoupon);
         } catch (DataIntegrityViolationException e) {
@@ -149,6 +167,24 @@ public class CouponServiceImpl implements CouponService {
                 .couponStatusCode(CouponStatus.UNUSED.getCode())
                 .barcodeNumber(generateUniqueBarcode())
                 .build();
+
+        if (template.getDiscountCode() != null) {
+            userActionLogProducer.sendLog(
+                    String.valueOf(userId),
+                    UserActionType.DOWNLOAD_FCFS_COUPON.name(),
+                    "eventPage",
+                    "benefit:" + template.getDiscountCode()
+            );
+        }
+
+        if (template.getMembershipCode() != null) {
+            userActionLogProducer.sendLog(
+                    String.valueOf(userId),
+                    UserActionType.DOWNLOAD_FCFS_COUPON.name(),
+                    "eventPage",
+                    "grade:" + template.getMembershipCode()
+            );
+        }
 
         try {
             userCouponRepository.save(userCoupon);

--- a/src/main/java/com/unear/userservice/coupon/service/impl/CouponServiceImpl.java
+++ b/src/main/java/com/unear/userservice/coupon/service/impl/CouponServiceImpl.java
@@ -117,23 +117,12 @@ public class CouponServiceImpl implements CouponService {
                 .build();
 
         if (template.getDiscountCode() != null) {
-            userActionLogProducer.sendLog(
-                    String.valueOf(userId),
-                    UserActionType.DOWNLOAD_COUPON.name(),
-                    "mapPage",
-                    "benefit:" + template.getDiscountCode()
-            );
+            userActionLogProducer.logUserAction(userId, UserActionType.DOWNLOAD_COUPON, "mapPage", "benefit:" + template.getDiscountCode());
         }
 
         if (template.getMembershipCode() != null) {
-            userActionLogProducer.sendLog(
-                    String.valueOf(userId),
-                    UserActionType.DOWNLOAD_COUPON.name(),
-                    "mapPage",
-                    "grade:" + template.getMembershipCode()
-            );
+            userActionLogProducer.logUserAction(userId, UserActionType.DOWNLOAD_COUPON, "mapPage", "grade:" + template.getMembershipCode());
         }
-
 
         try {
             userCouponRepository.save(userCoupon);
@@ -169,21 +158,11 @@ public class CouponServiceImpl implements CouponService {
                 .build();
 
         if (template.getDiscountCode() != null) {
-            userActionLogProducer.sendLog(
-                    String.valueOf(userId),
-                    UserActionType.DOWNLOAD_FCFS_COUPON.name(),
-                    "eventPage",
-                    "benefit:" + template.getDiscountCode()
-            );
+            userActionLogProducer.logUserAction(userId, UserActionType.DOWNLOAD_FCFS_COUPON, "eventPage", "benefit:" + template.getDiscountCode());
         }
 
         if (template.getMembershipCode() != null) {
-            userActionLogProducer.sendLog(
-                    String.valueOf(userId),
-                    UserActionType.DOWNLOAD_FCFS_COUPON.name(),
-                    "eventPage",
-                    "grade:" + template.getMembershipCode()
-            );
+            userActionLogProducer.logUserAction(userId, UserActionType.DOWNLOAD_FCFS_COUPON, "eventPage", "grade:" + template.getMembershipCode());
         }
 
         try {

--- a/src/main/java/com/unear/userservice/place/service/impl/PlaceServiceImpl.java
+++ b/src/main/java/com/unear/userservice/place/service/impl/PlaceServiceImpl.java
@@ -4,8 +4,10 @@ import com.unear.userservice.benefit.entity.GeneralDiscountPolicy;
 import com.unear.userservice.benefit.repository.FranchiseDiscountPolicyRepository;
 import com.unear.userservice.benefit.repository.GeneralDiscountPolicyRepository;
 import com.unear.userservice.common.enums.PlaceType;
+import com.unear.userservice.common.enums.UserActionType;
 import com.unear.userservice.common.exception.exception.PlaceNotFoundException;
 import com.unear.userservice.common.exception.exception.UserNotFoundException;
+import com.unear.userservice.common.redis.producer.UserActionLogProducer;
 import com.unear.userservice.coupon.dto.response.CouponResponseDto;
 import com.unear.userservice.coupon.entity.CouponTemplate;
 import com.unear.userservice.coupon.entity.UserCoupon;
@@ -33,6 +35,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+@Slf4j
 @Service
 @AllArgsConstructor
 public class PlaceServiceImpl implements PlaceService {
@@ -45,6 +48,7 @@ public class PlaceServiceImpl implements PlaceService {
     private final FranchiseDiscountPolicyRepository franchiseDiscountPolicyRepository;
     private final GeneralDiscountPolicyRepository generalDiscountPolicyRepository;
     private final BenefitDescriptionResolver benefitDescriptionResolver;
+    private final UserActionLogProducer userActionLogProducer;
 
     private List<String> nullIfBlank(List<String> list) {
         if (list == null) return List.of();
@@ -76,6 +80,51 @@ public class PlaceServiceImpl implements PlaceService {
         Set<Long> favorites = (userId != null)
                 ? favoritePlaceRepository.findPlaceIdsByUserId(userId)
                 : Collections.emptySet();
+
+
+        if (requestDto.getBenefitCategory() != null) {
+            for (String benefit : requestDto.getBenefitCategory()) {
+                try {
+                    userActionLogProducer.sendLog(
+                            String.valueOf(userId),
+                            UserActionType.PLACE_FILTER.name(),
+                            "mapPage",
+                            "benefit:" + benefit
+                    );
+                } catch (Exception e) {
+                    log.warn("benefitCategory 로그 전송 실패", e);
+                }
+            }
+        }
+
+        if (requestDto.getCategoryCode() != null) {
+            for (String category : requestDto.getCategoryCode()) {
+                try {
+                    userActionLogProducer.sendLog(
+                            String.valueOf(userId),
+                            UserActionType.PLACE_FILTER.name(),
+                            "mapPage",
+                            "category:" + category
+                    );
+                } catch (Exception e) {
+                    log.warn("categoryCode 로그 전송 실패", e);
+                }
+            }
+        }
+
+        if (requestDto.getKeyword() != null) {
+            try {
+                userActionLogProducer.sendLog(
+                        String.valueOf(userId),
+                        UserActionType.PLACE_KEYWORD.name(),
+                        "mapPage",
+                        "keyword:" + requestDto.getKeyword()
+                );
+            } catch (Exception e) {
+                log.warn("PLACE_KEYWORD 로그 전송 실패", e);
+            }
+        }
+
 
         return places.stream()
                 .map(place -> PlaceRenderResponseDto.from(place, favorites.contains(place.getPlaceId())))
@@ -172,6 +221,32 @@ public class PlaceServiceImpl implements PlaceService {
 
         String benefitDesc = benefitDescriptionResolver.resolveBenefitDesc(policyRef, membershipCode);
 
+        if (place.getCategoryCode() != null) {
+            try {
+                userActionLogProducer.sendLog(
+                        String.valueOf(userId),
+                        UserActionType.VIEW_PLACE_DETAIL.name(),
+                        "mapPage",
+                        "category:" + place.getCategoryCode()
+                );
+            } catch (Exception e) {
+                log.warn("VIEW_PLACE_DETAIL 로그 전송 실패", e);
+            }
+        }
+
+        if (place.getBenefitCategory() != null) {
+            try {
+                userActionLogProducer.sendLog(
+                        String.valueOf(userId),
+                        UserActionType.VIEW_PLACE_DETAIL.name(),
+                        "mapPage",
+                        "benefit:" + place.getBenefitCategory()
+                );
+            } catch (Exception e) {
+                log.warn("VIEW_PLACE_DETAIL 로그 전송 실패", e);
+            }
+        }
+
         return NearbyPlaceWithCouponsDto.builder()
                 .placeId(place.getPlaceId())
                 .name(place.getPlaceName())
@@ -207,6 +282,27 @@ public class PlaceServiceImpl implements PlaceService {
             boolean newStatus = !Boolean.TRUE.equals(favorite.getIsFavorited());
             favorite.setIsFavorited(newStatus);
             favorite.setDeletedAt(newStatus ? null : LocalDateTime.now());
+
+
+            if (newStatus) { // 즐겨찾기 ON일 때만 로그 전송
+                try {
+                    userActionLogProducer.sendLog(
+                            String.valueOf(userId),
+                            UserActionType.FAVORITE_ON.name(),
+                            "mapPage",
+                            "category:" + favorite.getPlace().getCategoryCode()
+                    );
+                    userActionLogProducer.sendLog(
+                            String.valueOf(userId),
+                            UserActionType.FAVORITE_ON.name(),
+                            "mapPage",
+                            "benefit:" + favorite.getPlace().getBenefitCategory()
+                    );
+                } catch (Exception e) {
+                    log.warn("즐겨찾기 로그 전송 실패", e);
+                }
+            }
+
             return newStatus;
         } else {
             FavoritePlace favorite = new FavoritePlace();

--- a/src/main/java/com/unear/userservice/place/service/impl/PlaceServiceImpl.java
+++ b/src/main/java/com/unear/userservice/place/service/impl/PlaceServiceImpl.java
@@ -84,45 +84,18 @@ public class PlaceServiceImpl implements PlaceService {
 
         if (requestDto.getBenefitCategory() != null) {
             for (String benefit : requestDto.getBenefitCategory()) {
-                try {
-                    userActionLogProducer.sendLog(
-                            String.valueOf(userId),
-                            UserActionType.PLACE_FILTER.name(),
-                            "mapPage",
-                            "benefit:" + benefit
-                    );
-                } catch (Exception e) {
-                    log.warn("benefitCategory 로그 전송 실패", e);
-                }
+                userActionLogProducer.logUserAction(userId, UserActionType.PLACE_FILTER, "mapPage", "benefit:" + benefit);
             }
         }
 
         if (requestDto.getCategoryCode() != null) {
             for (String category : requestDto.getCategoryCode()) {
-                try {
-                    userActionLogProducer.sendLog(
-                            String.valueOf(userId),
-                            UserActionType.PLACE_FILTER.name(),
-                            "mapPage",
-                            "category:" + category
-                    );
-                } catch (Exception e) {
-                    log.warn("categoryCode 로그 전송 실패", e);
-                }
+                userActionLogProducer.logUserAction(userId, UserActionType.PLACE_FILTER, "mapPage", "category:" + category);
             }
         }
 
         if (requestDto.getKeyword() != null) {
-            try {
-                userActionLogProducer.sendLog(
-                        String.valueOf(userId),
-                        UserActionType.PLACE_KEYWORD.name(),
-                        "mapPage",
-                        "keyword:" + requestDto.getKeyword()
-                );
-            } catch (Exception e) {
-                log.warn("PLACE_KEYWORD 로그 전송 실패", e);
-            }
+            userActionLogProducer.logUserAction(userId, UserActionType.PLACE_KEYWORD, "mapPage", "keyword:" + requestDto.getKeyword() );
         }
 
 
@@ -222,29 +195,11 @@ public class PlaceServiceImpl implements PlaceService {
         String benefitDesc = benefitDescriptionResolver.resolveBenefitDesc(policyRef, membershipCode);
 
         if (place.getCategoryCode() != null) {
-            try {
-                userActionLogProducer.sendLog(
-                        String.valueOf(userId),
-                        UserActionType.VIEW_PLACE_DETAIL.name(),
-                        "mapPage",
-                        "category:" + place.getCategoryCode()
-                );
-            } catch (Exception e) {
-                log.warn("VIEW_PLACE_DETAIL 로그 전송 실패", e);
-            }
+            userActionLogProducer.logUserAction(userId, UserActionType.VIEW_PLACE_DETAIL, "mapPage", "category:" + place.getCategoryCode());
         }
 
         if (place.getBenefitCategory() != null) {
-            try {
-                userActionLogProducer.sendLog(
-                        String.valueOf(userId),
-                        UserActionType.VIEW_PLACE_DETAIL.name(),
-                        "mapPage",
-                        "benefit:" + place.getBenefitCategory()
-                );
-            } catch (Exception e) {
-                log.warn("VIEW_PLACE_DETAIL 로그 전송 실패", e);
-            }
+            userActionLogProducer.logUserAction(userId, UserActionType.VIEW_PLACE_DETAIL, "mapPage", "benefit:" + place.getBenefitCategory());
         }
 
         return NearbyPlaceWithCouponsDto.builder()
@@ -284,22 +239,14 @@ public class PlaceServiceImpl implements PlaceService {
             favorite.setDeletedAt(newStatus ? null : LocalDateTime.now());
 
 
-            if (newStatus) { // 즐겨찾기 ON일 때만 로그 전송
-                try {
-                    userActionLogProducer.sendLog(
-                            String.valueOf(userId),
-                            UserActionType.FAVORITE_ON.name(),
-                            "mapPage",
-                            "category:" + favorite.getPlace().getCategoryCode()
-                    );
-                    userActionLogProducer.sendLog(
-                            String.valueOf(userId),
-                            UserActionType.FAVORITE_ON.name(),
-                            "mapPage",
-                            "benefit:" + favorite.getPlace().getBenefitCategory()
-                    );
-                } catch (Exception e) {
-                    log.warn("즐겨찾기 로그 전송 실패", e);
+            if (newStatus) {
+                Place place = favorite.getPlace();
+                if (place.getCategoryCode() != null) {
+                    userActionLogProducer.logUserAction(userId, UserActionType.FAVORITE_ON, "mapPage", "category:" + place.getCategoryCode());
+                }
+
+                if (place.getBenefitCategory() != null) {
+                    userActionLogProducer.logUserAction(userId, UserActionType.FAVORITE_ON, "mapPage", "benefit:" + place.getBenefitCategory());
                 }
             }
 


### PR DESCRIPTION
## PR 목적

- 사용자의 행동 로그 분석을 위한 Redis Producer 세팅
- 수집 대상의 api에 sendLog로 로그 정보 Redis에 저장


## 변경 사항

- 로그 저장 및 분석을 위한 user_action_logs , user_action_summary 테이블 추가
- RedisStream 저장 테스트
- 쿠폰 상세 조회시 브랜드명 필드 추가

## 주요 구현 내용

- UserActionLogProducer 로그 전송 producer 추가
- 사용자 행동유형 UserActionType Enum 추가
- DiscountPolicyServiceImpl -> getFranchiseDiscountPolicies / getFranchiseDiscountPolicyDetail 로그 수집
- CouponServiceImpl -> downloadCoupon / downloadFCFSCoupon 로그 수집
- PlaceServiceImpl -> getFilteredPlaces / getPlaceDetail / toggleFavorite 로그 수집
- UserCouponDetailResponseDto 에 brandName 필드 추가


## 병합 전 체크리스트

- [v] 로컬 테스트 완료
- [v] Postman 테스트 포함
- [v] 코드래빗 리뷰 검토
