### PR TITLE
[WL7-39] 유저 비밀번호 변경(기존 비밀번호 아는 상태) ( Add password change feature with new DTO, service, and controller endpoint )

### DIFF
--- a/src/main/java/com/unear/userservice/auth/controller/AuthController.java
+++ b/src/main/java/com/unear/userservice/auth/controller/AuthController.java
@@ -102,7 +102,7 @@ public class AuthController {
             @AuthenticationPrincipal CustomUser user,
             @RequestBody @Valid ChangePasswordRequestDto requestDto
     ) {
-        authService.changePassword(user.getId(), requestDto);
+        authService.changePassword(user.getUser().getUserId(), requestDto);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/unear/userservice/auth/controller/AuthController.java
+++ b/src/main/java/com/unear/userservice/auth/controller/AuthController.java
@@ -1,9 +1,6 @@
 package com.unear.userservice.auth.controller;
 
-import com.unear.userservice.auth.dto.request.CompleteProfileRequestDto;
-import com.unear.userservice.auth.dto.request.LoginRequestDto;
-import com.unear.userservice.auth.dto.request.ResetPasswordRequestDto;
-import com.unear.userservice.auth.dto.request.SignupRequestDto;
+import com.unear.userservice.auth.dto.request.*;
 import com.unear.userservice.auth.dto.response.LoginResponseDto;
 import com.unear.userservice.auth.dto.response.LogoutResponseDto;
 import com.unear.userservice.auth.dto.response.ProfileUpdateResponseDto;
@@ -98,6 +95,15 @@ public class AuthController {
         emailService.removeVerified(request.getEmail());
 
         return ResponseEntity.ok(ApiResponse.success("비밀번호가 성공적으로 재설정되었습니다."));
+    }
+
+    @PutMapping("/password")
+    public ResponseEntity<Void> changePassword(
+            @AuthenticationPrincipal CustomUser user,
+            @RequestBody @Valid ChangePasswordRequestDto requestDto
+    ) {
+        authService.changePassword(user.getId(), requestDto);
+        return ResponseEntity.ok().build();
     }
 
 }

--- a/src/main/java/com/unear/userservice/auth/dto/request/ChangePasswordRequestDto.java
+++ b/src/main/java/com/unear/userservice/auth/dto/request/ChangePasswordRequestDto.java
@@ -1,0 +1,14 @@
+package com.unear.userservice.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class ChangePasswordRequestDto {
+
+    @NotBlank(message = "현재 비밀번호를 입력해주세요.")
+    private String currentPassword;
+
+    @NotBlank(message = "새 비밀번호를 입력해주세요.")
+    private String newPassword;
+}

--- a/src/main/java/com/unear/userservice/auth/service/AuthService.java
+++ b/src/main/java/com/unear/userservice/auth/service/AuthService.java
@@ -1,9 +1,6 @@
 package com.unear.userservice.auth.service;
 
-import com.unear.userservice.auth.dto.request.CompleteProfileRequestDto;
-import com.unear.userservice.auth.dto.request.LoginRequestDto;
-import com.unear.userservice.auth.dto.request.ResetPasswordRequestDto;
-import com.unear.userservice.auth.dto.request.SignupRequestDto;
+import com.unear.userservice.auth.dto.request.*;
 import com.unear.userservice.auth.dto.response.LoginResponseDto;
 import com.unear.userservice.auth.dto.response.LogoutResponseDto;
 import com.unear.userservice.auth.dto.response.ProfileUpdateResponseDto;
@@ -31,4 +28,7 @@ public interface AuthService {
     ApiResponse<ProfileUpdateResponseDto> completeOAuthProfile(Long userId, @Valid CompleteProfileRequestDto request);
 
     User getUserFromAccessToken(String accessToken);
+
+    void changePassword(Long userId, ChangePasswordRequestDto dto); // 비밀번호 변경
+
 }

--- a/src/main/java/com/unear/userservice/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/unear/userservice/auth/service/impl/AuthServiceImpl.java
@@ -1,9 +1,7 @@
 package com.unear.userservice.auth.service.impl;
 
-import com.unear.userservice.auth.dto.request.CompleteProfileRequestDto;
-import com.unear.userservice.auth.dto.request.LoginRequestDto;
-import com.unear.userservice.auth.dto.request.ResetPasswordRequestDto;
-import com.unear.userservice.auth.dto.request.SignupRequestDto;
+import ch.qos.logback.core.spi.ErrorCodes;
+import com.unear.userservice.auth.dto.request.*;
 import com.unear.userservice.auth.dto.response.LoginResponseDto;
 import com.unear.userservice.auth.dto.response.LogoutResponseDto;
 import com.unear.userservice.auth.dto.response.ProfileUpdateResponseDto;
@@ -11,6 +9,8 @@ import com.unear.userservice.auth.dto.response.RefreshResponseDto;
 import com.unear.userservice.auth.dto.response.SignupResponseDto;
 import com.unear.userservice.auth.service.AuthService;
 import com.unear.userservice.common.enums.LoginProvider;
+import com.unear.userservice.common.exception.BusinessException;
+import com.unear.userservice.common.exception.ErrorCode;
 import com.unear.userservice.common.jwt.JwtTokenProvider;
 import com.unear.userservice.common.jwt.RefreshTokenService;
 import com.unear.userservice.common.response.ApiResponse;
@@ -24,6 +24,7 @@ import com.unear.userservice.user.entity.User;
 import com.unear.userservice.user.repository.UserRepository;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -202,5 +203,18 @@ public class AuthServiceImpl implements AuthService {
         Long userId = jwtTokenProvider.extractUserId(accessToken);
         return userRepository.findById(userId)
                 .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다"));
+    }
+
+    @Transactional
+    @Override
+    public void changePassword(Long userId, ChangePasswordRequestDto dto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(ErrorCode.USER_NOT_FOUND.getMessage()));
+
+        if (!passwordEncoder.matches(dto.getCurrentPassword(), user.getPassword())) {
+            throw new BusinessException(ErrorCode.INVALID_PASSWORD);
+        }
+
+        user.changePassword(dto.getNewPassword(), passwordEncoder);
     }
 }

--- a/src/main/java/com/unear/userservice/user/entity/User.java
+++ b/src/main/java/com/unear/userservice/user/entity/User.java
@@ -13,6 +13,7 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -71,4 +72,7 @@ public class User {
     @Column(name = "barcode_number", unique = true, nullable = false)
     private String barcodeNumber;
 
+    public void changePassword(String rawPassword, PasswordEncoder encoder) {
+        this.password = encoder.encode(rawPassword);
+    }
 }


### PR DESCRIPTION
## PR 목적

기존 비밀번호를 아는 상태에서 비밀번호 변경을 함



## 변경 사항

#118 



## 주요 구현 내용

transactional 어노테이션 추가 후 changepassword 메서드 추가
controller put 매핑으로 비밀번호 변경 로직 추가


## 테스트 및 동작 화면 (필요 시 첨부)

<img width="1068" height="577" alt="image" src="https://github.com/user-attachments/assets/8b4291fa-22f2-41b5-96a5-26b078550cce" />



## 리뷰 시 중점적으로 봐야 할 부분



## 병합 전 체크리스트

- [ ] 로컬 테스트 완료
- [ ] Postman 테스트 포함
- [ ] Swagger 동작 확인
- [ ] 코드래빗 리뷰 검토
