### PR TITLE
[WL-392] 유저 이메일 찾기 및 비밀번호 초기화

### DIFF
--- a/src/main/java/com/unear/userservice/auth/controller/AuthController.java
+++ b/src/main/java/com/unear/userservice/auth/controller/AuthController.java
@@ -1,11 +1,7 @@
 package com.unear.userservice.auth.controller;
 
 import com.unear.userservice.auth.dto.request.*;
-import com.unear.userservice.auth.dto.response.LoginResponseDto;
-import com.unear.userservice.auth.dto.response.LogoutResponseDto;
-import com.unear.userservice.auth.dto.response.ProfileUpdateResponseDto;
-import com.unear.userservice.auth.dto.response.RefreshResponseDto;
-import com.unear.userservice.auth.dto.response.SignupResponseDto;
+import com.unear.userservice.auth.dto.response.*;
 import com.unear.userservice.auth.service.AuthService;
 import com.unear.userservice.auth.service.EmailService;
 import com.unear.userservice.common.response.ApiResponse;
@@ -86,15 +82,10 @@ public class AuthController {
     }
 
     @PostMapping("/reset-password")
-    public ResponseEntity<ApiResponse<String>> resetPassword(@Valid @RequestBody ResetPasswordRequestDto request) {
-
-        if (!emailService.isVerified(request.getEmail())) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ApiResponse.fail(ErrorCode.EMAIL_NOT_VERIFIED));
-        }
-        authService.resetPassword(request);
-        emailService.removeVerified(request.getEmail());
-
-        return ResponseEntity.ok(ApiResponse.success("비밀번호가 성공적으로 재설정되었습니다."));
+    public ResponseEntity<ApiResponse<String>> resetPassword(
+            @RequestBody @Valid ResetPasswordRequestDto dto) {
+        authService.resetPassword(dto);
+        return ResponseEntity.ok(ApiResponse.success("비밀번호가 재설정되었습니다."));
     }
 
     @PutMapping("/password")
@@ -105,5 +96,29 @@ public class AuthController {
         authService.changePassword(user.getUser().getUserId(), requestDto);
         return ResponseEntity.ok().build();
     }
+
+    @PostMapping("/find-id")
+    public ResponseEntity<MaskedEmailResponseDto> findEmailByTel(
+            @RequestBody @Valid FindEmailRequestDto requestDto
+    ) {
+        String maskedEmail = authService.findMaskedEmailByTel(requestDto.getTel());
+        return ResponseEntity.ok(new MaskedEmailResponseDto(maskedEmail));
+    }
+
+    @PostMapping("/reset-password/send-code")
+    public ResponseEntity<Void> sendResetPasswordCode(
+            @RequestBody @Valid ResetPasswordEmailRequestDto requestDto
+    ) {
+        authService.sendResetPasswordCode(requestDto.getEmail());
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/reset-password/verify")
+    public ResponseEntity<ApiResponse<String>> verifyResetPasswordCode(
+            @RequestBody @Valid VerifyResetPasswordCodeRequestDto dto) {
+        authService.verifyResetPasswordCode(dto);
+        return ResponseEntity.ok(ApiResponse.success("인증코드 검증 성공"));
+    }
+
 
 }

--- a/src/main/java/com/unear/userservice/auth/dto/request/FindEmailRequestDto.java
+++ b/src/main/java/com/unear/userservice/auth/dto/request/FindEmailRequestDto.java
@@ -1,0 +1,11 @@
+package com.unear.userservice.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class FindEmailRequestDto {
+
+    @NotBlank(message = "전화번호를 입력해주세요.")
+    private String tel;
+}

--- a/src/main/java/com/unear/userservice/auth/dto/request/ResetPasswordEmailRequestDto.java
+++ b/src/main/java/com/unear/userservice/auth/dto/request/ResetPasswordEmailRequestDto.java
@@ -1,0 +1,13 @@
+package com.unear.userservice.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class ResetPasswordEmailRequestDto {
+
+    @NotBlank(message = "이메일을 입력해주세요.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String email;
+}

--- a/src/main/java/com/unear/userservice/auth/dto/request/VerifyResetPasswordCodeRequestDto.java
+++ b/src/main/java/com/unear/userservice/auth/dto/request/VerifyResetPasswordCodeRequestDto.java
@@ -1,0 +1,16 @@
+package com.unear.userservice.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class VerifyResetPasswordCodeRequestDto {
+
+    @NotBlank
+    @Email
+    private String email;
+
+    @NotBlank
+    private String code;
+}

--- a/src/main/java/com/unear/userservice/auth/dto/request/VerifyResetPasswordCodeRequestDto.java
+++ b/src/main/java/com/unear/userservice/auth/dto/request/VerifyResetPasswordCodeRequestDto.java
@@ -2,15 +2,16 @@ package com.unear.userservice.auth.dto.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 
 @Getter
 public class VerifyResetPasswordCodeRequestDto {
 
-    @NotBlank
-    @Email
+    @NotBlank(message = "이메일을 입력해주세요.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
     private String email;
-
-    @NotBlank
+    @NotBlank(message = "인증코드를 입력해주세요.")
+    @Pattern(regexp = "^[0-9]{4}$", message = "인증코드는 4자리 숫자여야 합니다.")
     private String code;
 }

--- a/src/main/java/com/unear/userservice/auth/dto/response/MaskedEmailResponseDto.java
+++ b/src/main/java/com/unear/userservice/auth/dto/response/MaskedEmailResponseDto.java
@@ -1,0 +1,11 @@
+package com.unear.userservice.auth.dto.response;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MaskedEmailResponseDto {
+    private String maskedEmail;
+}

--- a/src/main/java/com/unear/userservice/auth/service/AuthService.java
+++ b/src/main/java/com/unear/userservice/auth/service/AuthService.java
@@ -31,4 +31,9 @@ public interface AuthService {
 
     void changePassword(Long userId, ChangePasswordRequestDto dto); // 비밀번호 변경
 
+    String findMaskedEmailByTel(String tel);
+
+    void sendResetPasswordCode(String email);   // 비밀번호 재설정 인증코드 보내기
+
+    void verifyResetPasswordCode(VerifyResetPasswordCodeRequestDto dto); // 인증코드 검증
 }

--- a/src/main/java/com/unear/userservice/auth/service/EmailService.java
+++ b/src/main/java/com/unear/userservice/auth/service/EmailService.java
@@ -7,4 +7,5 @@ public interface EmailService {
     boolean verifyCode(String email, String code); // 인증코드 검증
     boolean isVerified(String email);
     void removeVerified(String email);
+    void sendResetPasswordCode(String email ,String code);
 }

--- a/src/main/java/com/unear/userservice/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/unear/userservice/auth/service/impl/AuthServiceImpl.java
@@ -185,7 +185,6 @@ public class AuthServiceImpl implements AuthService {
 
         userRepository.save(user);
 
-        // 비밀번호 재설정 완료 후 인증 상태 삭제
         redisTemplate.delete(key);
     }
 
@@ -244,13 +243,14 @@ public class AuthServiceImpl implements AuthService {
     }
     private String maskEmail(String email) {
         int atIndex = email.indexOf("@");
+        if (atIndex == -1) {
+            throw new IllegalArgumentException("올바른 이메일 형식이 아닙니다");
+        }
         String local = email.substring(0, atIndex);
         String domain = email.substring(atIndex + 1);
-
         int maskLength = Math.max(1, (int) (local.length() * 0.3));
         String visible = local.substring(0, local.length() - maskLength);
         String masked = "*".repeat(maskLength);
-
         return visible + masked + "@" + domain;
     }
 
@@ -271,7 +271,7 @@ public class AuthServiceImpl implements AuthService {
         );
 
         // 이메일 발송
-        emailService.sendResetPasswordCode(email,code); // 필요시 새로 정의
+        emailService.sendResetPasswordCode(email,code);
     }
 
     @Override
@@ -283,7 +283,7 @@ public class AuthServiceImpl implements AuthService {
             throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
         }
 
-        // 인증 성공 → 인증 상태 저장 (선택)
+        // 인증 성공 → 인증 상태 저장
         redisTemplate.opsForValue().set(RESET_PASSWORD_PREFIX + dto.getEmail(), "true", Duration.ofMinutes(10));
     }
 }

--- a/src/main/java/com/unear/userservice/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/unear/userservice/auth/service/impl/AuthServiceImpl.java
@@ -45,7 +45,7 @@ public class AuthServiceImpl implements AuthService {
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenService refreshTokenService;
     private final CustomUserDetailsService customUserDetailsService;
-    private static final String RESET_PASSWORD_PREFIX = "reset:";
+    private static final String RESET_PASSWORD_PREFIX = "resetVerified:";
     private final EmailService emailService;
     private final RedisTemplate<String, String> redisTemplate;
 
@@ -284,6 +284,6 @@ public class AuthServiceImpl implements AuthService {
         }
 
         // 인증 성공 → 인증 상태 저장 (선택)
-        redisTemplate.opsForValue().set("resetVerified:" + dto.getEmail(), "true", Duration.ofMinutes(10));
+        redisTemplate.opsForValue().set(RESET_PASSWORD_PREFIX + dto.getEmail(), "true", Duration.ofMinutes(10));
     }
 }

--- a/src/main/java/com/unear/userservice/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/unear/userservice/auth/service/impl/AuthServiceImpl.java
@@ -32,6 +32,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.security.SecureRandom;
 import java.time.Duration;
 import java.util.UUID;
 
@@ -185,6 +186,7 @@ public class AuthServiceImpl implements AuthService {
 
         userRepository.save(user);
 
+        // 비밀번호 재설정 완료 후 인증 상태 삭제
         redisTemplate.delete(key);
     }
 
@@ -256,22 +258,16 @@ public class AuthServiceImpl implements AuthService {
 
     @Override
     public void sendResetPasswordCode(String email) {
-        // 유저 존재 여부 확인
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new UserNotFoundException(ErrorCode.USER_NOT_FOUND.getMessage()));
-
-        // 인증 코드 생성 (예: 6자리 랜덤 숫자)
-        String code = String.valueOf((int)(Math.random() * 900000) + 100000); // 100000~999999
-
-        // Redis 저장 (TTL: 5분)
+        SecureRandom random = new SecureRandom();
+        String code = String.format("%06d", random.nextInt(1000000));
         redisTemplate.opsForValue().set(
                 RESET_PASSWORD_PREFIX + email,
                 code,
                 Duration.ofMinutes(5)
         );
-
-        // 이메일 발송
-        emailService.sendResetPasswordCode(email,code);
+        emailService.sendResetPasswordCode(email, code);
     }
 
     @Override
@@ -283,7 +279,7 @@ public class AuthServiceImpl implements AuthService {
             throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
         }
 
-        // 인증 성공 → 인증 상태 저장
+        // 인증 성공 → 인증 상태 저장 (선택)
         redisTemplate.opsForValue().set(RESET_PASSWORD_PREFIX + dto.getEmail(), "true", Duration.ofMinutes(10));
     }
 }

--- a/src/main/java/com/unear/userservice/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/unear/userservice/auth/service/impl/AuthServiceImpl.java
@@ -8,6 +8,7 @@ import com.unear.userservice.auth.dto.response.ProfileUpdateResponseDto;
 import com.unear.userservice.auth.dto.response.RefreshResponseDto;
 import com.unear.userservice.auth.dto.response.SignupResponseDto;
 import com.unear.userservice.auth.service.AuthService;
+import com.unear.userservice.auth.service.EmailService;
 import com.unear.userservice.common.enums.LoginProvider;
 import com.unear.userservice.common.exception.BusinessException;
 import com.unear.userservice.common.exception.ErrorCode;
@@ -27,9 +28,11 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
 import java.util.UUID;
 
 @Slf4j
@@ -42,6 +45,9 @@ public class AuthServiceImpl implements AuthService {
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenService refreshTokenService;
     private final CustomUserDetailsService customUserDetailsService;
+    private static final String RESET_PASSWORD_PREFIX = "reset:";
+    private final EmailService emailService;
+    private final RedisTemplate<String, String> redisTemplate;
 
     @Override
     public ApiResponse<LoginResponseDto> login(LoginRequestDto loginRequest, HttpServletResponse response) {
@@ -161,15 +167,26 @@ public class AuthServiceImpl implements AuthService {
         return ApiResponse.success("회원가입 성공", responseDto);
     }
 
+    @Transactional
     @Override
-    public void resetPassword(ResetPasswordRequestDto request) {
+    public void resetPassword(ResetPasswordRequestDto dto) {
+        String key = "resetVerified:" + dto.getEmail();
+        String verified = redisTemplate.opsForValue().get(key);
 
-        User user = userRepository.findByEmail(request.getEmail())
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이메일입니다."));
+        if (!"true".equals(verified)) {
+            throw new BusinessException(ErrorCode.EMAIL_NOT_VERIFIED);
+        }
 
-        String newEncodedPassword = passwordEncoder.encode(request.getNewPassword());
-        user.setPassword(newEncodedPassword);
+        User user = userRepository.findByEmail(dto.getEmail())
+                .orElseThrow(() -> new UserNotFoundException(ErrorCode.USER_NOT_FOUND.getMessage()));
+
+        String encodedPassword = passwordEncoder.encode(dto.getNewPassword());
+        user.setPassword(encodedPassword);
+
         userRepository.save(user);
+
+        // 비밀번호 재설정 완료 후 인증 상태 삭제
+        redisTemplate.delete(key);
     }
 
     @Override
@@ -216,5 +233,57 @@ public class AuthServiceImpl implements AuthService {
         }
 
         user.changePassword(dto.getNewPassword(), passwordEncoder);
+    }
+
+    @Override
+    public String findMaskedEmailByTel(String tel) {
+        User user = userRepository.findByTel(tel)
+                .orElseThrow(() -> new UserNotFoundException(ErrorCode.USER_NOT_FOUND.getMessage()));
+
+        return maskEmail(user.getEmail());
+    }
+    private String maskEmail(String email) {
+        int atIndex = email.indexOf("@");
+        String local = email.substring(0, atIndex);
+        String domain = email.substring(atIndex + 1);
+
+        int maskLength = Math.max(1, (int) (local.length() * 0.3));
+        String visible = local.substring(0, local.length() - maskLength);
+        String masked = "*".repeat(maskLength);
+
+        return visible + masked + "@" + domain;
+    }
+
+    @Override
+    public void sendResetPasswordCode(String email) {
+        // 유저 존재 여부 확인
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UserNotFoundException(ErrorCode.USER_NOT_FOUND.getMessage()));
+
+        // 인증 코드 생성 (예: 6자리 랜덤 숫자)
+        String code = String.valueOf((int)(Math.random() * 900000) + 100000); // 100000~999999
+
+        // Redis 저장 (TTL: 5분)
+        redisTemplate.opsForValue().set(
+                RESET_PASSWORD_PREFIX + email,
+                code,
+                Duration.ofMinutes(5)
+        );
+
+        // 이메일 발송
+        emailService.sendResetPasswordCode(email,code); // 필요시 새로 정의
+    }
+
+    @Override
+    public void verifyResetPasswordCode(VerifyResetPasswordCodeRequestDto dto) {
+        String key = RESET_PASSWORD_PREFIX + dto.getEmail();
+        String savedCode = redisTemplate.opsForValue().get(key);
+
+        if (savedCode == null || !savedCode.equals(dto.getCode())) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        // 인증 성공 → 인증 상태 저장 (선택)
+        redisTemplate.opsForValue().set("resetVerified:" + dto.getEmail(), "true", Duration.ofMinutes(10));
     }
 }

--- a/src/main/java/com/unear/userservice/auth/service/impl/EmailServiceImpl.java
+++ b/src/main/java/com/unear/userservice/auth/service/impl/EmailServiceImpl.java
@@ -36,6 +36,14 @@ public class EmailServiceImpl implements EmailService {
         mailSender.send(message);
     }
 
+    private void sendEmailWithSubject(String toEmail, String subject, String messageText) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(toEmail);
+        message.setSubject(subject);
+        message.setText(messageText);
+        mailSender.send(message);
+    }
+
     @Override
     public void saveCode(String email, String code) {
         redisTemplate.opsForValue().set("emailCode:" + email, code, Duration.ofMinutes(5));
@@ -60,6 +68,15 @@ public class EmailServiceImpl implements EmailService {
     @Override
     public void removeVerified(String email) {
         redisTemplate.delete("emailVerified:" + email);
+    }
+
+    @Override
+    public void sendResetPasswordCode(String email,String code) {
+        String subject = "[서비스명] 비밀번호 재설정 인증번호";
+        String message = "요청하신 비밀번호 재설정을 위한 인증번호는 다음과 같습니다.\n\n"
+                + "인증번호: " + code + "\n\n"
+                + "5분 내로 입력해 주세요.";
+        sendEmailWithSubject(email, subject, message);
     }
 
 }

--- a/src/main/java/com/unear/userservice/common/config/SecurityConfig.java
+++ b/src/main/java/com/unear/userservice/common/config/SecurityConfig.java
@@ -51,7 +51,7 @@ public class SecurityConfig {
             "/auth/verify-code",
             "/auth/send-code",
             "/auth/refresh",
-            "/auth/reset-password",
+            "/auth/reset-password/**",
             "/oauth2/**",
             "/v3/api-docs/**",
             "/swagger-ui/**",

--- a/src/main/java/com/unear/userservice/user/repository/UserRepository.java
+++ b/src/main/java/com/unear/userservice/user/repository/UserRepository.java
@@ -23,4 +23,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query("SELECT u.membershipCode FROM User u WHERE u.userId = :userId")
     String findMembershipCodeByUserId(@Param("userId") Long userId);
 
+    Optional<User> findByTel(String tel);
 }


### PR DESCRIPTION
## PR 목적

유저 비밀번호 초기화 및 이메일 찾기



## 변경 사항

#121 



## 주요 구현 내용




## 테스트 및 동작 화면 (필요 시 첨부)

<img width="944" height="501" alt="image" src="https://github.com/user-attachments/assets/d6fa98c2-1f16-4a3a-9e56-cad4b5f9b240" />

### 인증코드 확인
<img width="900" height="388" alt="image" src="https://github.com/user-attachments/assets/df55d889-a98c-4504-94b4-283be725d744" />

<img width="698" height="564" alt="image" src="https://github.com/user-attachments/assets/8645f2c1-543b-45b9-a314-915f3eeeef3c" />

<img width="781" height="536" alt="image" src="https://github.com/user-attachments/assets/c4b3df50-4b17-40d8-9ea0-22f70d4e5b0b" />




## 리뷰 시 중점적으로 봐야 할 부분



## 병합 전 체크리스트

- [x] 로컬 테스트 완료
- [x] Postman 테스트 포함
- [ ] Swagger 동작 확인
- [ ] 코드래빗 리뷰 검토
