### PR TITLE
[Wl7-309] 사용내역 기반 개인별 통계

### DIFF
--- a/src/main/java/com/unear/userservice/user/controller/UserController.java
+++ b/src/main/java/com/unear/userservice/user/controller/UserController.java
@@ -3,16 +3,18 @@ package com.unear.userservice.user.controller;
 import com.unear.userservice.common.response.ApiResponse;
 import com.unear.userservice.common.security.CustomUser;
 import com.unear.userservice.common.exception.exception.UserNotFoundException;
+import com.unear.userservice.user.dto.response.MyStatisticsDetailResponseDto;
+import com.unear.userservice.user.dto.response.MyStatisticsSummaryResponseDto;
+import com.unear.userservice.user.dto.response.UserHistoryResponseDto;
 import com.unear.userservice.user.dto.response.UserInfoResponseDto;
 import com.unear.userservice.user.entity.User;
 import com.unear.userservice.user.repository.UserRepository;
+import com.unear.userservice.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/users")
@@ -22,6 +24,7 @@ public class UserController {
     private static final String BARCODE_SUCCESS_MESSAGE = "바코드 조회 성공";
 
     private final UserRepository userRepository;
+    private final UserService userService;
 
     @GetMapping("/me/barcode")
     public ApiResponse<String> getMyBarcode(@AuthenticationPrincipal CustomUser user) {
@@ -40,5 +43,31 @@ public class UserController {
         return ApiResponse.success("사용자 정보 조회 성공", dto);
     }
 
+    @GetMapping("/me/statistics/summary")
+    public ApiResponse<MyStatisticsSummaryResponseDto> getMyStatisticsSummary(@AuthenticationPrincipal CustomUser user) {
+        MyStatisticsSummaryResponseDto summary = userService.getMySummary(user.getId());
+        return ApiResponse.success("마이페이지 요약 통계 조회 성공", summary);
+    }
+
+    @GetMapping("/me/usage-history")
+    public ApiResponse<Page<UserHistoryResponseDto>> getMyUsageHistory(
+            @AuthenticationPrincipal CustomUser user,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "8") int size) {
+
+        Page<UserHistoryResponseDto> result = userService.getUserUsageHistory(user.getId(), page, size);
+        return ApiResponse.success("이용내역 조회 성공", result);
+    }
+
+
+    @GetMapping("/me/statistics/detail")
+    public ApiResponse<MyStatisticsDetailResponseDto> getMyStatisticsDetail(
+            @AuthenticationPrincipal CustomUser user,
+            @RequestParam int year,
+            @RequestParam int month) {
+
+        MyStatisticsDetailResponseDto detail = userService.getMyStatisticsDetail(user.getId(), year, month);
+        return ApiResponse.success("개인 통계 상세 조회 성공", detail);
+    }
 
 }

--- a/src/main/java/com/unear/userservice/user/dto/response/MonthlyDiscountDto.java
+++ b/src/main/java/com/unear/userservice/user/dto/response/MonthlyDiscountDto.java
@@ -1,0 +1,11 @@
+package com.unear.userservice.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MonthlyDiscountDto {
+    private String month;
+    private Integer discount;
+}

--- a/src/main/java/com/unear/userservice/user/dto/response/MyStatisticsDetailResponseDto.java
+++ b/src/main/java/com/unear/userservice/user/dto/response/MyStatisticsDetailResponseDto.java
@@ -1,0 +1,23 @@
+package com.unear.userservice.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+@AllArgsConstructor
+public class MyStatisticsDetailResponseDto {
+
+    private Integer totalSpent;
+
+    private Integer totalDiscount;
+
+    private Map<String, Integer> discountByCategory;
+
+    private Map<String, Double> discountCategoryRatio;
+
+    private double spentChangeRatio;
+
+    private double discountChangeRatio;
+}

--- a/src/main/java/com/unear/userservice/user/dto/response/MyStatisticsDetailResponseDto.java
+++ b/src/main/java/com/unear/userservice/user/dto/response/MyStatisticsDetailResponseDto.java
@@ -3,6 +3,7 @@ package com.unear.userservice.user.dto.response;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.util.HashMap;
 import java.util.Map;
 
 @Getter
@@ -13,9 +14,9 @@ public class MyStatisticsDetailResponseDto {
 
     private Integer totalDiscount;
 
-    private Map<String, Integer> discountByCategory;
+    private Map<String, Integer> discountByCategory = new HashMap<>();
 
-    private Map<String, Double> discountCategoryRatio;
+    private Map<String, Double> discountCategoryRatio = new HashMap<>();
 
     private double spentChangeRatio;
 

--- a/src/main/java/com/unear/userservice/user/dto/response/MyStatisticsSummaryResponseDto.java
+++ b/src/main/java/com/unear/userservice/user/dto/response/MyStatisticsSummaryResponseDto.java
@@ -1,0 +1,13 @@
+package com.unear.userservice.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class MyStatisticsSummaryResponseDto {
+    private Integer thisMonthDiscount;
+    private List<MonthlyDiscountDto> recentMonthDiscounts;
+}

--- a/src/main/java/com/unear/userservice/user/dto/response/UserHistoryResponseDto.java
+++ b/src/main/java/com/unear/userservice/user/dto/response/UserHistoryResponseDto.java
@@ -1,0 +1,47 @@
+package com.unear.userservice.user.dto.response;
+
+import com.unear.userservice.user.entity.UserHistory;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class UserHistoryResponseDto {
+
+    private String placeName;
+
+    private LocalDateTime usedAt;
+
+    private Integer originalAmount;
+
+    private Integer totalDiscountAmount;
+
+    private Integer totalPaymentAmount;
+
+    private Boolean isCouponUsed;
+
+    private Boolean isMembershipUsed;
+
+    private String discountCode;
+
+    private String membershipCode;
+
+    private String placeCategory;
+
+    public static UserHistoryResponseDto from(UserHistory entity) {
+        return UserHistoryResponseDto.builder()
+                .usedAt(entity.getUsedAt())
+                .originalAmount(entity.getOriginalAmount())
+                .totalDiscountAmount(entity.getTotalDiscountAmount())
+                .totalPaymentAmount(entity.getTotalPaymentAmount())
+                .isCouponUsed(entity.getIsCouponUsed())
+                .isMembershipUsed(entity.getIsMembershipUsed())
+                .discountCode(entity.getDiscountCode())
+                .membershipCode(entity.getMembershipCode())
+                .placeCategory(entity.getPlaceCategory())
+                .build();
+    }
+}
+

--- a/src/main/java/com/unear/userservice/user/entity/UserHistory.java
+++ b/src/main/java/com/unear/userservice/user/entity/UserHistory.java
@@ -1,0 +1,53 @@
+package com.unear.userservice.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "user_histories")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userHistoryId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private Long userCouponId;
+
+    private Long placeId;
+
+    private LocalDateTime usedAt;
+
+    private Integer originalAmount;
+
+    private Integer membershipDiscountAmount;
+
+    private Integer couponDiscountAmount;
+
+    private Integer totalDiscountAmount;
+
+    private Integer totalPaymentAmount;
+
+    private Boolean isCouponUsed;
+
+    private Boolean isMembershipUsed;
+
+    private LocalDateTime paidAt;
+
+    private String discountCode;
+
+    private String membershipCode;
+
+    private String placeCategory;
+
+}
+

--- a/src/main/java/com/unear/userservice/user/repository/UserHistoryRepository.java
+++ b/src/main/java/com/unear/userservice/user/repository/UserHistoryRepository.java
@@ -1,0 +1,39 @@
+package com.unear.userservice.user.repository;
+
+import com.unear.userservice.user.entity.UserHistory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface UserHistoryRepository extends JpaRepository<UserHistory, Long> {
+
+
+    @Query(value = """
+        SELECT * FROM user_histories
+        WHERE user_id = :userId
+        AND TO_CHAR(used_at, 'YYYY-MM') IN (:yearMonths)
+        ORDER BY used_at DESC
+    """, nativeQuery = true)
+    List<UserHistory> findHistoriesByUserIdAndYearMonths(
+            @Param("userId") Long userId,
+            @Param("yearMonths") List<String> yearMonths);
+
+
+    Page<UserHistory> findByUser_UserId(Long userId, Pageable pageable);
+
+        @Query(value = """
+        SELECT * FROM user_histories
+        WHERE user_id = :userId
+        AND TO_CHAR(used_at, 'YYYY-MM') = :yearMonth
+    """, nativeQuery = true)
+    List<UserHistory> findByUserIdAndYearMonth(@Param("userId") Long userId,
+                                               @Param("yearMonth") String yearMonth);
+
+
+}

--- a/src/main/java/com/unear/userservice/user/service/UserService.java
+++ b/src/main/java/com/unear/userservice/user/service/UserService.java
@@ -1,9 +1,17 @@
 package com.unear.userservice.user.service;
 
 
+import com.unear.userservice.user.dto.response.MyStatisticsDetailResponseDto;
+import com.unear.userservice.user.dto.response.MyStatisticsSummaryResponseDto;
+import com.unear.userservice.user.dto.response.UserHistoryResponseDto;
 import com.unear.userservice.user.dto.response.UserInfoResponseDto;
+import org.springframework.data.domain.Page;
 
 public interface UserService {
     UserInfoResponseDto getUserInfo(Long userId);
     String getMembershipBarcode(Long userId);
+    MyStatisticsSummaryResponseDto getMySummary(Long userId);
+    Page<UserHistoryResponseDto> getUserUsageHistory(Long userId, int page, int size);
+    MyStatisticsDetailResponseDto getMyStatisticsDetail(Long userId, int year, int month);
+
 }

--- a/src/main/java/com/unear/userservice/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/unear/userservice/user/service/impl/UserServiceImpl.java
@@ -86,10 +86,16 @@ public class UserServiceImpl implements UserService {
         Pageable pageable = PageRequest.of(page, size, Sort.by("usedAt").descending());
         Page<UserHistory> histories = userHistoryRepository.findByUser_UserId(userId, pageable);
 
+        List<Long> placeIds = histories.stream()
+                .map(UserHistory::getPlaceId)
+                .distinct()
+                .collect(Collectors.toList());
+
+        Map<Long, String> placeNameMap = placeRepository.findAllById(placeIds).stream()
+                .collect(Collectors.toMap(Place::getPlaceId, Place::getPlaceName));
+
         return histories.map(h -> {
-            String placeName = placeRepository.findById(h.getPlaceId())
-                    .map(Place::getPlaceName)
-                    .orElse(null);
+            String placeName = placeNameMap.getOrDefault(h.getPlaceId(), null);
 
             return UserHistoryResponseDto.builder()
                     .placeName(placeName)
@@ -105,6 +111,7 @@ public class UserServiceImpl implements UserService {
                     .build();
         });
     }
+
 
     @Override
     public MyStatisticsDetailResponseDto getMyStatisticsDetail(Long userId, int year, int month) {

--- a/src/main/java/com/unear/userservice/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/unear/userservice/user/service/impl/UserServiceImpl.java
@@ -2,13 +2,25 @@ package com.unear.userservice.user.service.impl;
 
 import com.unear.userservice.common.exception.BusinessException;
 import com.unear.userservice.common.exception.ErrorCode;
-import com.unear.userservice.user.dto.response.UserInfoResponseDto;
+import com.unear.userservice.place.entity.Place;
+import com.unear.userservice.place.repository.PlaceRepository;
+import com.unear.userservice.user.dto.response.*;
 import com.unear.userservice.user.entity.User;
+import com.unear.userservice.user.entity.UserHistory;
+import com.unear.userservice.user.repository.UserHistoryRepository;
 import com.unear.userservice.user.repository.UserRepository;
 import com.unear.userservice.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.YearMonth;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -16,6 +28,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
+    private final PlaceRepository placeRepository;
+    private final UserHistoryRepository userHistoryRepository;
 
     @Override
     public UserInfoResponseDto getUserInfo(Long userId) {
@@ -30,4 +44,116 @@ public class UserServiceImpl implements UserService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
         return user.getBarcodeNumber();
     }
+
+
+    @Override
+    public MyStatisticsSummaryResponseDto getMySummary(Long userId) {
+        YearMonth thisMonth = YearMonth.now();
+
+        List<String> last5Months = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            last5Months.add(thisMonth.minusMonths(i).toString());
+        }
+
+        List<UserHistory> last5 = userHistoryRepository.findHistoriesByUserIdAndYearMonths(userId, last5Months);
+
+        int thisMonthTotalDiscount = last5.stream()
+                .filter(h -> YearMonth.from(h.getUsedAt()).equals(thisMonth))
+                .mapToInt(h -> Optional.ofNullable(h.getTotalDiscountAmount()).orElse(0))
+                .sum();
+
+        Map<YearMonth, Integer> monthToDiscountMap = last5.stream()
+                .collect(Collectors.groupingBy(
+                        h -> YearMonth.from(h.getUsedAt()),
+                        Collectors.summingInt(h -> Optional.ofNullable(h.getTotalDiscountAmount()).orElse(0))
+                ));
+
+        List<MonthlyDiscountDto> recentDiscounts = last5Months.stream()
+                .map(ymStr -> {
+                    YearMonth ym = YearMonth.parse(ymStr);
+                    int discount = monthToDiscountMap.getOrDefault(ym, 0);
+                    return new MonthlyDiscountDto(ymStr, discount);
+                })
+                .toList();
+
+        return new MyStatisticsSummaryResponseDto(thisMonthTotalDiscount, recentDiscounts);
+    }
+
+
+
+    @Override
+    public Page<UserHistoryResponseDto> getUserUsageHistory(Long userId, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("usedAt").descending());
+        Page<UserHistory> histories = userHistoryRepository.findByUser_UserId(userId, pageable);
+
+        return histories.map(h -> {
+            String placeName = placeRepository.findById(h.getPlaceId())
+                    .map(Place::getPlaceName)
+                    .orElse(null);
+
+            return UserHistoryResponseDto.builder()
+                    .placeName(placeName)
+                    .usedAt(h.getUsedAt())
+                    .originalAmount(h.getOriginalAmount())
+                    .totalDiscountAmount(h.getTotalDiscountAmount())
+                    .totalPaymentAmount(h.getTotalPaymentAmount())
+                    .isCouponUsed(h.getIsCouponUsed())
+                    .isMembershipUsed(h.getIsMembershipUsed())
+                    .discountCode(h.getDiscountCode())
+                    .membershipCode(h.getMembershipCode())
+                    .placeCategory(h.getPlaceCategory())
+                    .build();
+        });
+    }
+
+    @Override
+    public MyStatisticsDetailResponseDto getMyStatisticsDetail(Long userId, int year, int month) {
+        YearMonth thisMonth = YearMonth.of(year, month);
+        String thisMonthStr = thisMonth.toString();
+        List<UserHistory> thisMonthHistories = userHistoryRepository.findByUserIdAndYearMonth(userId, thisMonthStr);
+
+        int thisSpent = thisMonthHistories.stream().mapToInt(UserHistory::getTotalPaymentAmount).sum();
+        int thisDiscount = thisMonthHistories.stream().mapToInt(UserHistory::getTotalDiscountAmount).sum();
+
+        YearMonth lastMonth = thisMonth.minusMonths(1);
+        String lastMonthStr = lastMonth.toString();
+        List<UserHistory> lastMonthHistories = userHistoryRepository.findByUserIdAndYearMonth(userId, lastMonthStr);
+
+        int lastSpent = lastMonthHistories.stream().mapToInt(UserHistory::getTotalPaymentAmount).sum();
+        int lastDiscount = lastMonthHistories.stream().mapToInt(UserHistory::getTotalDiscountAmount).sum();
+
+        double spentChangeRatio = (lastSpent != 0)
+                ? Math.round(((thisSpent - lastSpent) * 1000.0 / lastSpent)) / 10.0
+                : 0.0;
+
+        double discountChangeRatio = (lastDiscount != 0)
+                ? Math.round(((thisDiscount - lastDiscount) * 1000.0 / lastDiscount)) / 10.0
+                : 0.0;
+
+        Map<String, Integer> discountPerCategory = new HashMap<>();
+        for (UserHistory history : thisMonthHistories) {
+            String category = history.getPlaceCategory();
+            discountPerCategory.merge(category, history.getTotalDiscountAmount(), Integer::sum);
+        }
+
+        Map<String, Double> discountCategoryRatio = new HashMap<>();
+        for (Map.Entry<String, Integer> entry : discountPerCategory.entrySet()) {
+            double ratio = (thisDiscount > 0)
+                    ? Math.round(entry.getValue() * 1000.0 / thisDiscount) / 10.0
+                    : 0.0;
+            discountCategoryRatio.put(entry.getKey(), ratio);
+        }
+
+        return new MyStatisticsDetailResponseDto(
+                thisSpent,
+                thisDiscount,
+                discountPerCategory,
+                discountCategoryRatio,
+                spentChangeRatio,
+                discountChangeRatio
+        );
+    }
+
+
+
 }

--- a/src/main/java/com/unear/userservice/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/unear/userservice/user/service/impl/UserServiceImpl.java
@@ -116,40 +116,35 @@ public class UserServiceImpl implements UserService {
     @Override
     public MyStatisticsDetailResponseDto getMyStatisticsDetail(Long userId, int year, int month) {
         YearMonth thisMonth = YearMonth.of(year, month);
+        YearMonth lastMonth = thisMonth.minusMonths(1);
+
         String thisMonthStr = thisMonth.toString();
+        String lastMonthStr = lastMonth.toString();
+
         List<UserHistory> thisMonthHistories = userHistoryRepository.findByUserIdAndYearMonth(userId, thisMonthStr);
+        List<UserHistory> lastMonthHistories = userHistoryRepository.findByUserIdAndYearMonth(userId, lastMonthStr);
 
         int thisSpent = thisMonthHistories.stream().mapToInt(UserHistory::getTotalPaymentAmount).sum();
         int thisDiscount = thisMonthHistories.stream().mapToInt(UserHistory::getTotalDiscountAmount).sum();
-
-        YearMonth lastMonth = thisMonth.minusMonths(1);
-        String lastMonthStr = lastMonth.toString();
-        List<UserHistory> lastMonthHistories = userHistoryRepository.findByUserIdAndYearMonth(userId, lastMonthStr);
-
         int lastSpent = lastMonthHistories.stream().mapToInt(UserHistory::getTotalPaymentAmount).sum();
         int lastDiscount = lastMonthHistories.stream().mapToInt(UserHistory::getTotalDiscountAmount).sum();
 
-        double spentChangeRatio = (lastSpent != 0)
-                ? Math.round(((thisSpent - lastSpent) * 1000.0 / lastSpent)) / 10.0
-                : 0.0;
+        double spentChangeRatio = calculateChangeRatio(thisSpent, lastSpent);
+        double discountChangeRatio = calculateChangeRatio(thisDiscount, lastDiscount);
 
-        double discountChangeRatio = (lastDiscount != 0)
-                ? Math.round(((thisDiscount - lastDiscount) * 1000.0 / lastDiscount)) / 10.0
-                : 0.0;
+        Map<String, Integer> discountPerCategory = thisMonthHistories.stream()
+                .collect(Collectors.groupingBy(
+                        UserHistory::getPlaceCategory,
+                        Collectors.summingInt(UserHistory::getTotalDiscountAmount)
+                ));
 
-        Map<String, Integer> discountPerCategory = new HashMap<>();
-        for (UserHistory history : thisMonthHistories) {
-            String category = history.getPlaceCategory();
-            discountPerCategory.merge(category, history.getTotalDiscountAmount(), Integer::sum);
-        }
-
-        Map<String, Double> discountCategoryRatio = new HashMap<>();
-        for (Map.Entry<String, Integer> entry : discountPerCategory.entrySet()) {
-            double ratio = (thisDiscount > 0)
-                    ? Math.round(entry.getValue() * 1000.0 / thisDiscount) / 10.0
-                    : 0.0;
-            discountCategoryRatio.put(entry.getKey(), ratio);
-        }
+        Map<String, Double> discountCategoryRatio = discountPerCategory.entrySet().stream()
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        entry -> thisDiscount > 0
+                                ? Math.round(entry.getValue() * 1000.0 / thisDiscount) / 10.0
+                                : 0.0
+                ));
 
         return new MyStatisticsDetailResponseDto(
                 thisSpent,
@@ -160,6 +155,13 @@ public class UserServiceImpl implements UserService {
                 discountChangeRatio
         );
     }
+
+    private double calculateChangeRatio(int current, int previous) {
+        if (previous == 0) return 0.0;
+        return Math.round(((current - previous) * 100.0 / previous) * 10) / 10.0;
+    }
+
+
 
 
 


### PR DESCRIPTION
## PR 목적

- 마이페이지에서 사용되는 개인별 통계 및 결제내역 조회 api 추가
- 마이페이지 통계 요약 / 이용내역 페이지네이션 / 개인별 통계 상세 api 추가

## 변경 사항

- /users/me/statistics/summary api 추가
- /users/me/usage-history api 추가
- /users/me/statistics/detail api 추가

## 주요 구현 내용

- UserHistory 엔티티, 레포지토리 추가
- 사용내역 responseDto 추가
- getMySummary 마이페이지 요약 통계 조회 로직 추가
- getUserUsageHistory 이용내역 조회 로직 추가
- getMyStatisticsDetail 개인별 통계 상세조회 추가
- UserHistoryRepository nativeQuery 추가


## 병합 전 체크리스트

- [v] 로컬 테스트 완료
- [v] Postman 테스트 포함
- [v] 코드래빗 리뷰 검토
