### PR TITLE
[WL7-423] 스탬프 event_id 기준으로 조회 ( Refactor stamp retrieval with improved exceptions and DTO structure )

### DIFF
--- a/src/main/java/com/unear/userservice/common/exception/exception/EventNotFoundException.java
+++ b/src/main/java/com/unear/userservice/common/exception/exception/EventNotFoundException.java
@@ -1,0 +1,7 @@
+package com.unear.userservice.common.exception.exception;
+
+public class EventNotFoundException extends RuntimeException {
+    public EventNotFoundException(Long eventId) {
+        super("이벤트를 찾을 수 없습니다: id=" + eventId);
+    }
+}

--- a/src/main/java/com/unear/userservice/event/entity/UnearEvent.java
+++ b/src/main/java/com/unear/userservice/event/entity/UnearEvent.java
@@ -3,6 +3,7 @@ package com.unear.userservice.event.entity;
 import com.unear.userservice.coupon.entity.CouponTemplate;
 import com.unear.userservice.place.entity.EventPlace;
 import com.unear.userservice.roulette.entity.RouletteResult;
+import com.unear.userservice.stamp.entity.Stamp;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
@@ -44,6 +45,9 @@ public class UnearEvent {
 
     @OneToMany(mappedBy = "event", fetch = FetchType.LAZY)
     private List<CouponTemplate> couponTemplates = new ArrayList<>();
+
+    @OneToMany(mappedBy = "event")
+    private List<Stamp> stamps = new ArrayList<>();
 
 }
 

--- a/src/main/java/com/unear/userservice/stamp/controller/StampController.java
+++ b/src/main/java/com/unear/userservice/stamp/controller/StampController.java
@@ -3,10 +3,9 @@ package com.unear.userservice.stamp.controller;
 import com.unear.userservice.common.docs.stamp.StampApiDocs;
 import com.unear.userservice.common.response.ApiResponse;
 import com.unear.userservice.common.security.CustomUser;
-import com.unear.userservice.stamp.dto.response.EventStampResponseDto;
+import com.unear.userservice.stamp.dto.response.StampStatusResponseDto;
 import com.unear.userservice.stamp.service.StampService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -21,12 +20,11 @@ public class StampController {
     private final StampService stampService;
 
     @StampApiDocs.GetMyStampStatus
-    @GetMapping("/events/{eventId}/me")
-    public ResponseEntity<ApiResponse<EventStampResponseDto>> getMyStampsForEvent(
+    @GetMapping("events/{eventId}/me")
+    public ApiResponse<StampStatusResponseDto> getMyStamps(
             @AuthenticationPrincipal CustomUser user,
             @PathVariable Long eventId
     ) {
-        EventStampResponseDto response = stampService.getMyStampsForEvent(user.getId(), eventId);
-        return ResponseEntity.ok(ApiResponse.success("스탬프 조회 성공", response));
+        return ApiResponse.success(stampService.getMyStampsForEvent(user.getId(), eventId));
     }
 }

--- a/src/main/java/com/unear/userservice/stamp/domain/EventStampPolicy.java
+++ b/src/main/java/com/unear/userservice/stamp/domain/EventStampPolicy.java
@@ -2,8 +2,21 @@ package com.unear.userservice.stamp.domain;
 
 
 import com.unear.userservice.common.enums.EventType;
+import com.unear.userservice.place.entity.EventPlace;
+
+import java.util.List;
 
 public class EventStampPolicy {
+
+    private final List<EventPlace> eventPlaces;
+
+    private EventStampPolicy(List<EventPlace> eventPlaces) {
+        this.eventPlaces = eventPlaces;
+    }
+
+    public static EventStampPolicy of(List<EventPlace> eventPlaces) {
+        return new EventStampPolicy(eventPlaces);
+    }
 
     public boolean isSatisfiedBy(StampCollection collection) {
         long require = collection.getStamps().stream()
@@ -15,5 +28,9 @@ public class EventStampPolicy {
                 .count();
 
         return require >= 1 && general >= 3;
+    }
+
+    public List<EventPlace> getEventPlaces() {
+        return eventPlaces;
     }
 }

--- a/src/main/java/com/unear/userservice/stamp/domain/StampCollection.java
+++ b/src/main/java/com/unear/userservice/stamp/domain/StampCollection.java
@@ -1,5 +1,6 @@
 package com.unear.userservice.stamp.domain;
 
+import com.unear.userservice.stamp.dto.response.StampStatusResponseDto;
 import com.unear.userservice.stamp.entity.Stamp;
 import lombok.Getter;
 
@@ -7,9 +8,26 @@ import java.util.List;
 
 @Getter
 public class StampCollection {
+
     private final List<Stamp> stamps;
+    private final boolean rouletteEnabled;
+
+    public StampCollection(List<Stamp> stamps, boolean rouletteEnabled) {
+        this.stamps = stamps;
+        this.rouletteEnabled = rouletteEnabled;
+    }
 
     public StampCollection(List<Stamp> stamps) {
-        this.stamps = stamps;
+        this(stamps, false);
+    }
+
+    public static StampCollection of(List<Stamp> stamps, EventStampPolicy policy) {
+        boolean isSatisfied = policy.isSatisfiedBy(new StampCollection(stamps));
+        return new StampCollection(stamps, isSatisfied);
+    }
+
+
+    public StampStatusResponseDto toResponseDto() {
+        return StampStatusResponseDto.of(this.stamps, this.rouletteEnabled);
     }
 }

--- a/src/main/java/com/unear/userservice/stamp/dto/response/StampResponseDto.java
+++ b/src/main/java/com/unear/userservice/stamp/dto/response/StampResponseDto.java
@@ -6,21 +6,22 @@ import lombok.*;
 import java.time.LocalDateTime;
 
 @Getter
-@Builder
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class StampResponseDto {
-    private Long stampId;
-    private String placeName;       // 예: 성수동 팝업스토어
-    private String eventCode;       // 예: REQUIRE, GENERAL
-    private LocalDateTime stampedAt;
+    private Long eventPlaceId;
+    private String placeName;
+    private String eventCode;
+    private boolean stamped;
 
     public static StampResponseDto from(Stamp stamp) {
         return StampResponseDto.builder()
-                .stampId(stamp.getStampId())
-                .placeName(stamp.getPlaceName())
-                .eventCode(stamp.getEventCode())
-                .stampedAt(stamp.getStampedAt())
+                .eventPlaceId(stamp.getEventPlace().getEventPlaceId())
+                .placeName(stamp.getEventPlace().getPlace().getPlaceName())
+                .eventCode(stamp.getEventPlace().getEventCode().name())
+                .stamped(true)
                 .build();
     }
 }

--- a/src/main/java/com/unear/userservice/stamp/dto/response/StampStatusResponseDto.java
+++ b/src/main/java/com/unear/userservice/stamp/dto/response/StampStatusResponseDto.java
@@ -24,4 +24,5 @@ public class StampStatusResponseDto {
 
         return new StampStatusResponseDto(dtoList, rouletteAvailable);
     }
+
 }

--- a/src/main/java/com/unear/userservice/stamp/entity/Stamp.java
+++ b/src/main/java/com/unear/userservice/stamp/entity/Stamp.java
@@ -1,5 +1,6 @@
 package com.unear.userservice.stamp.entity;
 
+import com.unear.userservice.event.entity.UnearEvent;
 import com.unear.userservice.place.entity.EventPlace;
 import com.unear.userservice.user.entity.User;
 import jakarta.persistence.*;
@@ -27,5 +28,9 @@ public class Stamp {
     private LocalDateTime stampedAt;
     private String eventCode;
     private String placeName;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "unear_event_id")
+    private UnearEvent event;
 }
 

--- a/src/main/java/com/unear/userservice/stamp/repository/StampRepository.java
+++ b/src/main/java/com/unear/userservice/stamp/repository/StampRepository.java
@@ -6,5 +6,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface StampRepository extends JpaRepository<Stamp, Long> {
-    List<Stamp> findByUser_UserIdAndEventPlace_Event_UnearEventId(Long userId, Long eventId);
+    List<Stamp> findByUser_UserIdAndEvent_UnearEventId(Long userId, Long eventId);
+
+//    List<Stamp> findByUserIdAndEvent_UnearEventId(Long userId, Long eventId);
+
 }

--- a/src/main/java/com/unear/userservice/stamp/service/StampService.java
+++ b/src/main/java/com/unear/userservice/stamp/service/StampService.java
@@ -1,7 +1,8 @@
 package com.unear.userservice.stamp.service;
 
 import com.unear.userservice.stamp.dto.response.EventStampResponseDto;
+import com.unear.userservice.stamp.dto.response.StampStatusResponseDto;
 
 public interface StampService {
-    EventStampResponseDto getMyStampsForEvent(Long userId, Long eventId);
+    StampStatusResponseDto getMyStampsForEvent(Long userId, Long eventId);
 }

--- a/src/main/java/com/unear/userservice/stamp/service/StampService.java
+++ b/src/main/java/com/unear/userservice/stamp/service/StampService.java
@@ -1,6 +1,5 @@
 package com.unear.userservice.stamp.service;
 
-import com.unear.userservice.stamp.dto.response.EventStampResponseDto;
 import com.unear.userservice.stamp.dto.response.StampStatusResponseDto;
 
 public interface StampService {

--- a/src/main/java/com/unear/userservice/stamp/service/impl/StampServiceImpl.java
+++ b/src/main/java/com/unear/userservice/stamp/service/impl/StampServiceImpl.java
@@ -1,12 +1,12 @@
 package com.unear.userservice.stamp.service.impl;
 
+import com.unear.userservice.common.exception.exception.EventNotFoundException;
 import com.unear.userservice.event.entity.UnearEvent;
 import com.unear.userservice.event.repository.EventRepository;
-import com.unear.userservice.place.entity.EventPlace;
 import com.unear.userservice.place.repository.EventPlaceRepository;
 import com.unear.userservice.stamp.domain.EventStampPolicy;
 import com.unear.userservice.stamp.domain.StampCollection;
-import com.unear.userservice.stamp.dto.response.EventStampResponseDto;
+import com.unear.userservice.stamp.dto.response.StampStatusResponseDto;
 import com.unear.userservice.stamp.entity.Stamp;
 import com.unear.userservice.stamp.repository.StampRepository;
 import com.unear.userservice.stamp.service.StampService;
@@ -26,17 +26,15 @@ public class StampServiceImpl implements StampService {
     private final StampRepository stampRepository;
 
     @Override
-    public EventStampResponseDto getMyStampsForEvent(Long userId, Long eventId) {
+    public StampStatusResponseDto getMyStampsForEvent(Long userId, Long eventId) {
         UnearEvent event = eventRepository.findById(eventId)
-                .orElseThrow(() -> new IllegalArgumentException("이벤트가 존재하지 않습니다"));
+                .orElseThrow(() -> new EventNotFoundException(eventId));
 
-        List<EventPlace> eventPlaces = eventPlaceRepository.findByEvent_UnearEventId(eventId);
-        List<Stamp> userStamps = stampRepository.findByUser_UserIdAndEventPlace_Event_UnearEventId(userId, eventId);
+        List<Stamp> stamps = stampRepository.findByUser_UserIdAndEvent_UnearEventId(userId, eventId);
 
-        StampCollection collection = new StampCollection(userStamps);
-        EventStampPolicy policy = new EventStampPolicy();
-        boolean available = policy.isSatisfiedBy(collection);
+        EventStampPolicy policy = EventStampPolicy.of(event.getEventPlaces());
+        StampCollection collection = StampCollection.of(stamps, policy);
 
-        return EventStampResponseDto.of(eventPlaces, userStamps, available);
+        return collection.toResponseDto();  // 최종 응답
     }
 }


### PR DESCRIPTION
## PR 목적

스탬프 조회를 event_id 로 조회할수 있도록



## 변경 사항

#133 


## 주요 구현 내용




## 테스트 및 동작 화면 (필요 시 첨부)




## 리뷰 시 중점적으로 봐야 할 부분




## 병합 전 체크리스트

- [ ] 로컬 테스트 완료
- [ ] Postman 테스트 포함
- [ ] Swagger 동작 확인
- [ ] 코드래빗 리뷰 검토
