### PR TITLE
[WL7-432] 진단 페이지 초안 ( Add consumption story diagnosis feature with API and related components )

### DIFF
--- a/src/main/java/com/unear/userservice/common/docs/story/StoryApiDocs.java
+++ b/src/main/java/com/unear/userservice/common/docs/story/StoryApiDocs.java
@@ -1,0 +1,49 @@
+package com.unear.userservice.common.docs.story;
+
+import com.unear.userservice.story.dto.response.StoryDiagnosisResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+public class StoryApiDocs {
+
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @Documented
+    @Operation(
+            summary = "소비 진단 결과 조회",
+            description = "사용자의 최근 소비 내역을 기반으로 AI가 생성한 결제 타입과 코멘트를 반환합니다."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "소비 진단 결과 조회 성공",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = StoryDiagnosisResponseDto.class),
+                    examples = {
+                            @ExampleObject(
+                                    name = "AI 소비 진단 예시",
+                                    summary = "진단 결과 예시",
+                                    value = """
+                                            {
+                                              "resultCode": 200,
+                                              "codeName": "SUCCESS",
+                                              "message": "소비 진단 결과 조회 성공",
+                                              "data": {
+                                                "type": "쩝쩝박사",
+                                                "comment": "축제의 즐거움은 맛에 있다고 믿는 당신! 다양한 먹거리를 탐험하며..."
+                                              }
+                                            }
+                                            """
+                            )
+                    }
+            )
+    )
+    @SecurityRequirement(name = "BearerAuth")
+    public @interface GetDiagnosis {}
+}

--- a/src/main/java/com/unear/userservice/stamp/domain/StampCollection.java
+++ b/src/main/java/com/unear/userservice/stamp/domain/StampCollection.java
@@ -10,11 +10,11 @@ import java.util.List;
 public class StampCollection {
 
     private final List<Stamp> stamps;
-    private final boolean rouletteEnabled;
+    private final boolean rouletteAvailable;
 
-    public StampCollection(List<Stamp> stamps, boolean rouletteEnabled) {
+    public StampCollection(List<Stamp> stamps, boolean rouletteAvailable) {
         this.stamps = stamps;
-        this.rouletteEnabled = rouletteEnabled;
+        this.rouletteAvailable = rouletteAvailable;
     }
 
     public StampCollection(List<Stamp> stamps) {
@@ -28,6 +28,6 @@ public class StampCollection {
 
 
     public StampStatusResponseDto toResponseDto() {
-        return StampStatusResponseDto.of(this.stamps, this.rouletteEnabled);
+        return StampStatusResponseDto.of(this.stamps, this.rouletteAvailable);
     }
 }

--- a/src/main/java/com/unear/userservice/story/controller/StoryController.java
+++ b/src/main/java/com/unear/userservice/story/controller/StoryController.java
@@ -11,7 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/story")
+@RequestMapping("/story")
 @RequiredArgsConstructor
 public class StoryController {
 

--- a/src/main/java/com/unear/userservice/story/controller/StoryController.java
+++ b/src/main/java/com/unear/userservice/story/controller/StoryController.java
@@ -1,0 +1,26 @@
+package com.unear.userservice.story.controller;
+
+import com.unear.userservice.common.annotation.LoginUser;
+import com.unear.userservice.common.docs.story.StoryApiDocs;
+import com.unear.userservice.common.response.ApiResponse;
+import com.unear.userservice.story.dto.response.StoryDiagnosisResponseDto;
+import com.unear.userservice.story.service.StoryService;
+import com.unear.userservice.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/story")
+@RequiredArgsConstructor
+public class StoryController {
+
+    private final StoryService storyService;
+
+    @GetMapping("/diagnosis")
+    @StoryApiDocs.GetDiagnosis
+    public ResponseEntity<ApiResponse<StoryDiagnosisResponseDto>> getDiagnosis(@LoginUser User user) {
+        StoryDiagnosisResponseDto response = storyService.getDiagnosis(user.getUserId());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/unear/userservice/story/dto/response/StoryDiagnosisResponseDto.java
+++ b/src/main/java/com/unear/userservice/story/dto/response/StoryDiagnosisResponseDto.java
@@ -1,0 +1,9 @@
+package com.unear.userservice.story.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record StoryDiagnosisResponseDto(
+        String type,
+        String comment
+) {}

--- a/src/main/java/com/unear/userservice/story/service/StoryService.java
+++ b/src/main/java/com/unear/userservice/story/service/StoryService.java
@@ -1,0 +1,8 @@
+package com.unear.userservice.story.service;
+
+import com.unear.userservice.story.dto.response.StoryDiagnosisResponseDto;
+
+public interface StoryService {
+    StoryDiagnosisResponseDto getDiagnosis(Long userId);
+}
+

--- a/src/main/java/com/unear/userservice/story/service/impl/StoryServiceImpl.java
+++ b/src/main/java/com/unear/userservice/story/service/impl/StoryServiceImpl.java
@@ -1,0 +1,41 @@
+package com.unear.userservice.story.service.impl;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.unear.userservice.story.dto.response.StoryDiagnosisResponseDto;
+import com.unear.userservice.story.service.StoryService;
+import com.unear.userservice.story.util.StoryAnalysisUtil;
+import com.unear.userservice.story.util.StoryAiClient;
+import com.unear.userservice.story.vo.UserAnalysisResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class StoryServiceImpl implements StoryService {
+
+    private final StoryAnalysisUtil analysisUtil;
+    private final StoryAiClient aiClient;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public StoryDiagnosisResponseDto getDiagnosis(Long userId) {
+        // 1. 사용자 소비 내역 분석
+        UserAnalysisResult analysisResult = analysisUtil.analyze(userId);
+
+        // 2. 프롬프트 생성 후 AI 호출
+        String prompt = aiClient.generatePrompt(analysisResult);
+        String aiResponse = aiClient.requestDiagnosis(prompt);
+
+        // 3. AI 응답 파싱
+        try {
+            JsonNode node = objectMapper.readTree(aiResponse);
+            return StoryDiagnosisResponseDto.builder()
+                    .type(node.get("type").asText())
+                    .comment(node.get("comment").asText())
+                    .build();
+        } catch (Exception e) {
+            throw new RuntimeException("AI 응답 파싱 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/unear/userservice/story/util/StoryAiClient.java
+++ b/src/main/java/com/unear/userservice/story/util/StoryAiClient.java
@@ -1,0 +1,31 @@
+package com.unear.userservice.story.util;
+
+import com.unear.userservice.story.vo.UserAnalysisResult;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StoryAiClient {
+
+    public String generatePrompt(UserAnalysisResult result) {
+        return String.format("""
+            사용자의 최근 소비 분석 결과입니다:
+            - 음식 비중: %.2f%%
+            - 평균 결제 금액: %d원
+            - 주요 활동: %s
+
+            위 정보를 기반으로 사용자의 결제 타입(type)과 설명(comment)을 JSON 형태로 생성해줘.
+            """, result.foodRate(), result.avgAmount(), result.activitySummary());
+    }
+
+    public String requestDiagnosis(String prompt) {
+        // TODO: 나중에 실제 OpenAI API 호출로 대체
+
+        // 지금은 하드코딩된 임시 JSON 응답
+        return """
+            {
+              "type": "쩝쩝박사",
+              "comment": "축제의 즐거움은 맛에 있다고 믿는 당신! 다양한 먹거리를 탐험하며..."
+            }
+        """;
+    }
+}

--- a/src/main/java/com/unear/userservice/story/util/StoryAnalysisUtil.java
+++ b/src/main/java/com/unear/userservice/story/util/StoryAnalysisUtil.java
@@ -1,0 +1,19 @@
+package com.unear.userservice.story.util;
+
+import com.unear.userservice.story.vo.UserAnalysisResult;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StoryAnalysisUtil {
+
+    public UserAnalysisResult analyze(Long userId) {
+        // TODO: 나중에 소비내역 조회 및 정교한 분석 로직 구현
+
+        // 지금은 임시 하드코딩된 분석 결과 반환
+        return UserAnalysisResult.builder()
+                .foodRate(72.3)
+                .avgAmount(14300)
+                .activitySummary("배달, 간편식, 길거리 음식 중심 소비")
+                .build();
+    }
+}

--- a/src/main/java/com/unear/userservice/story/vo/UserAnalysisResult.java
+++ b/src/main/java/com/unear/userservice/story/vo/UserAnalysisResult.java
@@ -1,0 +1,10 @@
+package com.unear.userservice.story.vo;
+
+import lombok.Builder;
+
+@Builder
+public record UserAnalysisResult(
+        double foodRate,
+        int avgAmount,
+        String activitySummary
+) {}

--- a/src/main/java/com/unear/userservice/user/entity/User.java
+++ b/src/main/java/com/unear/userservice/user/entity/User.java
@@ -6,10 +6,7 @@ import com.unear.userservice.place.entity.FavoritePlace;
 import com.unear.userservice.roulette.entity.RouletteResult;
 import com.unear.userservice.stamp.entity.Stamp;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -20,6 +17,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
+@Getter
 @Data
 @Builder
 @AllArgsConstructor


### PR DESCRIPTION
## PR 목적

프론트에 넘겨줄 목적으로 빠르게 엔드포인트만 구현
나머지 분석및 응답은 다 목업입니다. 프론트 분들 확인하면 바로 수정  들어가겠습니다


## 변경 사항





## 주요 구현 내용

진단 페이지 controller 엔드포인트 구현

## 테스트 및 동작 화면 (필요 시 첨부)
<img width="1026" height="688" alt="image" src="https://github.com/user-attachments/assets/df556c46-468f-4a62-ac96-1c3762cf5f50" />




## 리뷰 시 중점적으로 봐야 할 부분

X



## 병합 전 체크리스트

- [ ] 로컬 테스트 완료
- [ ] Postman 테스트 포함
- [ ] Swagger 동작 확인
- [ ] 코드래빗 리뷰 검토
