### PR TITLE
[WL7-436] 소비내역 히스토리 페이지 초안 ( Add consumption history API endpoint, DTOs, service, and Swagger annotation )

### DIFF
--- a/src/main/java/com/unear/userservice/common/docs/story/StoryApiDocs.java
+++ b/src/main/java/com/unear/userservice/common/docs/story/StoryApiDocs.java
@@ -60,7 +60,8 @@ public class StoryApiDocs {
             description = "소비 히스토리 조회 성공",
             content = @Content(
                     mediaType = "application/json",
-                    schema = @Schema(implementation = StoryHistoryResponseDto.class),
+                    schema = @Schema(implementation = StoryHistoryResponseDto.class,
+                                     type = "array"),
                     examples = {
                             @ExampleObject(
                                     name = "소비 히스토리 조회 예시",

--- a/src/main/java/com/unear/userservice/common/docs/story/StoryApiDocs.java
+++ b/src/main/java/com/unear/userservice/common/docs/story/StoryApiDocs.java
@@ -24,7 +24,7 @@ public class StoryApiDocs {
             description = "소비 진단 결과 조회 성공",
             content = @Content(
                     mediaType = "application/json",
-                    schema = @Schema(implementation = StoryDiagnosisResponseDto.class),
+                    schema = @Schema(implementation = StoryHistoryResponseDto.class),
                     examples = {
                             @ExampleObject(
                                     name = "AI 소비 진단 예시",

--- a/src/main/java/com/unear/userservice/common/docs/story/StoryApiDocs.java
+++ b/src/main/java/com/unear/userservice/common/docs/story/StoryApiDocs.java
@@ -46,4 +46,50 @@ public class StoryApiDocs {
     )
     @SecurityRequirement(name = "BearerAuth")
     public @interface GetDiagnosis {}
+
+
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @Documented
+    @Operation(
+            summary = "소비 히스토리 조회",
+            description = "사용자의 최근 3달 소비 내역을 기반으로 스토리와 코멘트를 반환합니다."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "소비 히스토리 조회 성공",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = StoryDiagnosisResponseDto.class),
+                    examples = {
+                            @ExampleObject(
+                                    name = "소비 히스토리 조회 예시",
+                                    summary = "조회 결과 예시",
+                                    value = """
+                                            {
+                                                "resultCode": 200,
+                                                "codeName": "SUCCESS",
+                                                "message": "요청이 성공적으로 처리되었습니다.",
+                                                "data": [
+                                                    {
+                                                        "month": "2025-08",
+                                                        "type": "쩝쩝박사",
+                                                        "comment": "축제의 즐거움은 맛에 있다고 믿는 당신!",
+                                                        "imageUrl": "https://cdn.unear.site/story/type/zzep.png"
+                                                    },
+                                                    {
+                                                        "month": "2025-07",
+                                                        "type": "알뜰소비러",
+                                                        "comment": "혜택은 놓치지 않는다! 알뜰하고 계획적인 당신!",
+                                                        "imageUrl": "https://cdn.unear.site/story/type/saver.png"
+                                                    }
+                                                ]
+                                            }
+                                            """
+                            )
+                    }
+            )
+    )
+    @SecurityRequirement(name = "BearerAuth")
+    public @interface GetHistory {}
 }

--- a/src/main/java/com/unear/userservice/common/docs/story/StoryApiDocs.java
+++ b/src/main/java/com/unear/userservice/common/docs/story/StoryApiDocs.java
@@ -24,7 +24,7 @@ public class StoryApiDocs {
             description = "소비 진단 결과 조회 성공",
             content = @Content(
                     mediaType = "application/json",
-                    schema = @Schema(implementation = StoryHistoryResponseDto.class),
+                    schema = @Schema(implementation = StoryDiagnosisResponseDto.class),
                     examples = {
                             @ExampleObject(
                                     name = "AI 소비 진단 예시",
@@ -60,7 +60,7 @@ public class StoryApiDocs {
             description = "소비 히스토리 조회 성공",
             content = @Content(
                     mediaType = "application/json",
-                    schema = @Schema(implementation = StoryDiagnosisResponseDto.class),
+                    schema = @Schema(implementation = StoryHistoryResponseDto.class),
                     examples = {
                             @ExampleObject(
                                     name = "소비 히스토리 조회 예시",

--- a/src/main/java/com/unear/userservice/story/controller/StoryController.java
+++ b/src/main/java/com/unear/userservice/story/controller/StoryController.java
@@ -4,11 +4,14 @@ import com.unear.userservice.common.annotation.LoginUser;
 import com.unear.userservice.common.docs.story.StoryApiDocs;
 import com.unear.userservice.common.response.ApiResponse;
 import com.unear.userservice.story.dto.response.StoryDiagnosisResponseDto;
+import com.unear.userservice.story.dto.response.StoryHistoryResponseDto;
 import com.unear.userservice.story.service.StoryService;
 import com.unear.userservice.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/story")
@@ -22,5 +25,12 @@ public class StoryController {
     public ResponseEntity<ApiResponse<StoryDiagnosisResponseDto>> getDiagnosis(@LoginUser User user) {
         StoryDiagnosisResponseDto response = storyService.getDiagnosis(user.getUserId());
         return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/history")
+    @StoryApiDocs.GetHistory
+    public ResponseEntity<ApiResponse<List<StoryHistoryResponseDto>>> getHistory(@LoginUser User user) {
+        List<StoryHistoryResponseDto> history = storyService.getHistory(user.getUserId());
+        return ResponseEntity.ok(ApiResponse.success(history));
     }
 }

--- a/src/main/java/com/unear/userservice/story/dto/response/StoryHistoryResponseDto.java
+++ b/src/main/java/com/unear/userservice/story/dto/response/StoryHistoryResponseDto.java
@@ -1,0 +1,13 @@
+package com.unear.userservice.story.dto.response;
+
+import lombok.Builder;
+
+import java.time.YearMonth;
+
+@Builder
+public record StoryHistoryResponseDto(
+        YearMonth month,
+        String type,
+        String comment,
+        String imageUrl
+) {}

--- a/src/main/java/com/unear/userservice/story/service/StoryService.java
+++ b/src/main/java/com/unear/userservice/story/service/StoryService.java
@@ -1,8 +1,12 @@
 package com.unear.userservice.story.service;
 
 import com.unear.userservice.story.dto.response.StoryDiagnosisResponseDto;
+import com.unear.userservice.story.dto.response.StoryHistoryResponseDto;
+
+import java.util.List;
 
 public interface StoryService {
     StoryDiagnosisResponseDto getDiagnosis(Long userId);
+    List<StoryHistoryResponseDto> getHistory(Long userId);
 }
 

--- a/src/main/java/com/unear/userservice/story/service/impl/StoryServiceImpl.java
+++ b/src/main/java/com/unear/userservice/story/service/impl/StoryServiceImpl.java
@@ -3,12 +3,16 @@ package com.unear.userservice.story.service.impl;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.unear.userservice.story.dto.response.StoryDiagnosisResponseDto;
+import com.unear.userservice.story.dto.response.StoryHistoryResponseDto;
 import com.unear.userservice.story.service.StoryService;
 import com.unear.userservice.story.util.StoryAnalysisUtil;
 import com.unear.userservice.story.util.StoryAiClient;
 import com.unear.userservice.story.vo.UserAnalysisResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.time.YearMonth;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -37,5 +41,25 @@ public class StoryServiceImpl implements StoryService {
         } catch (Exception e) {
             throw new RuntimeException("AI 응답 파싱 실패", e);
         }
+    }
+
+    @Override
+    public List<StoryHistoryResponseDto> getHistory(Long userId) {
+        // TODO: 임시 데이터, 추후 DB 또는 AI 진단 기반으로 대체
+        return List.of(
+                StoryHistoryResponseDto.builder()
+                        .month(YearMonth.of(2025, 8))
+                        .type("쩝쩝박사")
+                        .comment("축제의 즐거움은 맛에 있다고 믿는 당신!")
+                        .imageUrl("https://cdn.unear.site/story/type/zzep.png")
+                        .build(),
+
+                StoryHistoryResponseDto.builder()
+                        .month(YearMonth.of(2025, 7))
+                        .type("알뜰소비러")
+                        .comment("혜택은 놓치지 않는다! 알뜰하고 계획적인 당신!")
+                        .imageUrl("https://cdn.unear.site/story/type/saver.png")
+                        .build()
+        );
     }
 }


### PR DESCRIPTION
## PR 목적

t소비내역 히스토리 API 의 엔드포인트를 정의한 초안 입니다.
나머지 코드들은 협의후 전부 수정 예정입니다.



## 변경 사항

#139 

## 주요 구현 내용

소비 히스토리 controller 엔드포인트 구현


## 테스트 및 동작 화면 (필요 시 첨부)

<img width="885" height="721" alt="image" src="https://github.com/user-attachments/assets/1c938c01-f691-4bd9-83fb-a2c9a84c86ce" />



## 리뷰 시 중점적으로 봐야 할 부분


## 병합 전 체크리스트

- [ ] 로컬 테스트 완료
- [ ] Postman 테스트 포함
- [ ] Swagger 동작 확인
- [ ] 코드래빗 리뷰 검토
