### PR TITLE
[WL7-437] 소비스토리 페이지 초안 ( Add API endpoint to provide current month info on story page )

### DIFF
--- a/src/main/java/com/unear/userservice/common/docs/story/StoryApiDocs.java
+++ b/src/main/java/com/unear/userservice/common/docs/story/StoryApiDocs.java
@@ -1,5 +1,6 @@
 package com.unear.userservice.common.docs.story;
 
+import com.unear.userservice.story.dto.response.StoryCurrentResponseDto;
 import com.unear.userservice.story.dto.response.StoryDiagnosisResponseDto;
 import com.unear.userservice.story.dto.response.StoryHistoryResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -94,4 +95,43 @@ public class StoryApiDocs {
     )
     @SecurityRequirement(name = "BearerAuth")
     public @interface GetHistory {}
+
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @Documented
+    @Operation(
+            summary = "이번 달 스토리 조회",
+            description = "한 줄 멘트 + 대표 결제 내역 + 일러스트 이미지를 포함한 스토리 상세 화면에 사용됩니다."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "이번 달 스토리 응답",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = StoryCurrentResponseDto.class),
+                    examples = {
+                            @ExampleObject(
+                                    name = "스토리 상세 예시",
+                                    value = """
+                                            {
+                                              "success": true,
+                                              "data": {
+                                                "month": "2025-07",
+                                                "comment": "맛있는 음식 도착 소식에, 행복해지는 순간이 찾아왔어.",
+                                                "imageUrl": "https://cdn.unear.site/story/current/zzep_full.png",
+                                                "representativeLog": {
+                                                  "date": "2025-07-15",
+                                                  "storeName": "맥도날드 치즈버거",
+                                                  "amount": 14200,
+                                                  "logoUrl": "https://cdn.unear.site/logo/mcdonalds.png"
+                                                }
+                                              }
+                                            }
+                                            """
+                            )
+                    }
+            )
+    )
+    @SecurityRequirement(name = "BearerAuth")
+    public @interface GetCurrent {}
 }

--- a/src/main/java/com/unear/userservice/story/controller/StoryController.java
+++ b/src/main/java/com/unear/userservice/story/controller/StoryController.java
@@ -3,6 +3,7 @@ package com.unear.userservice.story.controller;
 import com.unear.userservice.common.annotation.LoginUser;
 import com.unear.userservice.common.docs.story.StoryApiDocs;
 import com.unear.userservice.common.response.ApiResponse;
+import com.unear.userservice.story.dto.response.StoryCurrentResponseDto;
 import com.unear.userservice.story.dto.response.StoryDiagnosisResponseDto;
 import com.unear.userservice.story.dto.response.StoryHistoryResponseDto;
 import com.unear.userservice.story.service.StoryService;
@@ -32,5 +33,12 @@ public class StoryController {
     public ResponseEntity<ApiResponse<List<StoryHistoryResponseDto>>> getHistory(@LoginUser User user) {
         List<StoryHistoryResponseDto> history = storyService.getHistory(user.getUserId());
         return ResponseEntity.ok(ApiResponse.success(history));
+    }
+
+    @GetMapping("/current")
+    @StoryApiDocs.GetCurrent
+    public ResponseEntity<ApiResponse<StoryCurrentResponseDto>> getCurrentStory(@LoginUser User user) {
+        StoryCurrentResponseDto response = storyService.getCurrent(user.getUserId());
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/unear/userservice/story/dto/response/StoryCurrentResponseDto.java
+++ b/src/main/java/com/unear/userservice/story/dto/response/StoryCurrentResponseDto.java
@@ -1,0 +1,22 @@
+package com.unear.userservice.story.dto.response;
+
+import lombok.Builder;
+
+import java.time.YearMonth;
+import java.time.LocalDate;
+
+@Builder
+public record StoryCurrentResponseDto(
+        YearMonth month,
+        String comment,
+        String imageUrl,
+        RepresentativeLog representativeLog
+) {
+    @Builder
+    public record RepresentativeLog(
+            LocalDate date,
+            String storeName,
+            int amount,
+            String logoUrl
+    ) {}
+}

--- a/src/main/java/com/unear/userservice/story/service/StoryService.java
+++ b/src/main/java/com/unear/userservice/story/service/StoryService.java
@@ -1,5 +1,6 @@
 package com.unear.userservice.story.service;
 
+import com.unear.userservice.story.dto.response.StoryCurrentResponseDto;
 import com.unear.userservice.story.dto.response.StoryDiagnosisResponseDto;
 import com.unear.userservice.story.dto.response.StoryHistoryResponseDto;
 
@@ -8,5 +9,6 @@ import java.util.List;
 public interface StoryService {
     StoryDiagnosisResponseDto getDiagnosis(Long userId);
     List<StoryHistoryResponseDto> getHistory(Long userId);
+    StoryCurrentResponseDto getCurrent(Long userId);
 }
 

--- a/src/main/java/com/unear/userservice/story/service/impl/StoryServiceImpl.java
+++ b/src/main/java/com/unear/userservice/story/service/impl/StoryServiceImpl.java
@@ -2,6 +2,7 @@ package com.unear.userservice.story.service.impl;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.unear.userservice.story.dto.response.StoryCurrentResponseDto;
 import com.unear.userservice.story.dto.response.StoryDiagnosisResponseDto;
 import com.unear.userservice.story.dto.response.StoryHistoryResponseDto;
 import com.unear.userservice.story.service.StoryService;
@@ -11,6 +12,7 @@ import com.unear.userservice.story.vo.UserAnalysisResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.List;
 
@@ -61,5 +63,24 @@ public class StoryServiceImpl implements StoryService {
                         .imageUrl("https://cdn.unear.site/story/type/saver.png")
                         .build()
         );
+    }
+
+    @Override
+    public StoryCurrentResponseDto getCurrent(Long userId) {
+        // 대표 결제 내역
+        StoryCurrentResponseDto.RepresentativeLog repLog =
+                StoryCurrentResponseDto.RepresentativeLog.builder()
+                        .date(LocalDate.of(2025, 7, 15))
+                        .storeName("맥도날드 치즈버거")
+                        .amount(14200)
+                        .logoUrl("https://cdn.unear.site/logo/mcdonalds.png")
+                        .build();
+
+        return StoryCurrentResponseDto.builder()
+                .month(YearMonth.of(2025, 7))
+                .comment("맛있는 음식 도착 소식에, 행복해지는 순간이 찾아왔어.")
+                .imageUrl("https://cdn.unear.site/story/current/zzep_full.png")
+                .representativeLog(repLog)
+                .build();
     }
 }


### PR DESCRIPTION
## PR 목적

소비스토리 페이지 API 엔드포인트 만 정의 
심화작업은 프론트 스웨거 확인후 진행하겠습니다



## 변경 사항

#141 

## 주요 구현 내용

스토리 Controller 엔드포인트 구현

## 테스트 및 동작 화면 (필요 시 첨부)

<img width="1124" height="809" alt="image" src="https://github.com/user-attachments/assets/a646ccf6-0816-49b7-bcd3-588b3ae5c0d5" />

## 리뷰 시 중점적으로 봐야 할 부분


## 병합 전 체크리스트

- [x] 로컬 테스트 완료
- [x] Postman 테스트 포함
- [ ] Swagger 동작 확인
- [x] 코드래빗 리뷰 검토
