### PR TITLE
[Wl7-42] MembershipGrade 순서 추가

### DIFF
--- a/src/main/java/com/unear/userservice/benefit/dto/response/FranchiseDiscountPolicyDetailResponseDto.java
+++ b/src/main/java/com/unear/userservice/benefit/dto/response/FranchiseDiscountPolicyDetailResponseDto.java
@@ -1,11 +1,12 @@
 package com.unear.userservice.benefit.dto.response;
 
-import com.unear.userservice.benefit.entity.FranchiseDiscountPolicy;
+import com.unear.userservice.common.enums.MembershipGrade;
 import com.unear.userservice.place.entity.Franchise;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.Comparator;
 import java.util.List;
 
 @Getter
@@ -23,6 +24,8 @@ public class FranchiseDiscountPolicyDetailResponseDto {
     public static FranchiseDiscountPolicyDetailResponseDto from(Franchise franchise) {
         List<MembershipGradePolicyResponseDto> policies = franchise.getFranchiseDiscountPolicies().stream()
                 .map(MembershipGradePolicyResponseDto::from)
+                .sorted(Comparator.comparingInt(p ->
+                        MembershipGrade.fromCode(p.getMembershipCode()).getPriority()))
                 .toList();
 
         return new FranchiseDiscountPolicyDetailResponseDto(
@@ -33,8 +36,6 @@ public class FranchiseDiscountPolicyDetailResponseDto {
                 policies
         );
     }
-
-
 }
 
 

--- a/src/main/java/com/unear/userservice/common/enums/MembershipGrade.java
+++ b/src/main/java/com/unear/userservice/common/enums/MembershipGrade.java
@@ -8,17 +8,19 @@ import java.util.Arrays;
 @Getter
 public enum MembershipGrade {
 
-    BASIC("BASIC", "우수"),
-    VIP("VIP", "VIP"),
-    VVIP("VVIP", "VVIP"),
-    ALL("ALL", "모든등급");
+    VVIP("VVIP", "VVIP", 1),
+    VIP("VIP", "VIP", 2),
+    BASIC("BASIC", "우수", 3),
+    ALL("ALL", "모든등급", 4);
 
     private final String code;
     private final String label;
+    private final int priority;
 
-    MembershipGrade(String code, String label) {
+    MembershipGrade(String code, String label, int priority) {
         this.code = code;
         this.label = label;
+        this.priority = priority;
     }
 
     public static MembershipGrade fromCode(String code) {
@@ -31,5 +33,4 @@ public enum MembershipGrade {
     public static boolean isAll(String code) {
         return ALL.code.equalsIgnoreCase(code);
     }
-
 }


### PR DESCRIPTION
## PR 목적

- 프랜차이즈 혜택 상세조회시, VVIP -> VIP -> BASIC 순서로 반환되도록 수정


## 주요 구현 내용

- MembershipGrade -> priority 필드 추가 ( 정렬 기준 )
- FranchiseDiscountPolicyDetailResponseDto -> from 메서드 enum 정렬 기준으로 반환되도록 수정

## 병합 전 체크리스트

- [v] 로컬 테스트 완료
- [v] Postman 테스트 포함
- [v] 코드래빗 리뷰 검토
